### PR TITLE
Feature/647 Monitor Plan Unit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ lerna-debug.log*
 # Tests
 /coverage
 /.nyc_output
+test-report.xml
 
 # IDEs and editors
 /.idea

--- a/src/monitor-location/monitor-location.controller.spec.ts
+++ b/src/monitor-location/monitor-location.controller.spec.ts
@@ -1,0 +1,26 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+
+import { MonitorLocationController } from './monitor-location.controller';
+import { MonitorLocationService } from './monitor-location.service';
+
+describe('-- Monitor Locations Controller --', () => {
+  let monitorLocationController: MonitorLocationController;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [MonitorLocationController],
+      providers: [MonitorLocationService, ConfigService],
+    }).compile();
+
+    monitorLocationController = module.get(MonitorLocationController);
+  });
+
+  describe('* getMonitorLocations', () => {
+    it('should call the service and return static data', async () => {
+      const result = monitorLocationController.getMonitorLocations();
+
+      expect(result).toBe('Hello getMonitorLocations!');
+    });
+  });
+});

--- a/src/monitor-location/monitor-location.repository.spec.ts
+++ b/src/monitor-location/monitor-location.repository.spec.ts
@@ -1,0 +1,50 @@
+import { Test } from '@nestjs/testing';
+import { SelectQueryBuilder } from 'typeorm';
+
+import { MonitorLocationRepository } from './monitor-location.repository';
+import { MonitorLocation } from '../entities/monitor-location.entity';
+
+const mockQueryBuilder = () => ({
+  innerJoinAndSelect: jest.fn(),
+  leftJoinAndSelect: jest.fn(),
+  addOrderBy: jest.fn(),
+  getMany: jest.fn(),
+});
+
+describe('-- Monitor Locations Repository --', () => {
+  let monitorLocationRepository;
+  let queryBuilder;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MonitorLocationRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+      ],
+    }).compile();
+
+    monitorLocationRepository = module.get(MonitorLocationRepository);
+    queryBuilder = module.get<SelectQueryBuilder<MonitorLocation>>(
+      SelectQueryBuilder,
+    );
+  });
+
+  describe('getMonitorLocationsByFacId', () => {
+    it('calls createQueryBuilder and gets all MonitorLocations from the repository with the specified facId', async () => {
+      monitorLocationRepository.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(queryBuilder);
+      queryBuilder.innerJoinAndSelect.mockReturnValue(queryBuilder);
+      queryBuilder.leftJoinAndSelect.mockReturnValue(queryBuilder);
+      queryBuilder.addOrderBy.mockReturnValue(queryBuilder);
+      queryBuilder.getMany.mockReturnValue('mockMonitorLocations');
+
+      const result = await monitorLocationRepository.getMonitorLocationsByFacId(
+        0,
+      );
+
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(result).toEqual('mockMonitorLocations');
+    });
+  });
+});

--- a/src/monitor-location/monitor-location.service.spec.ts
+++ b/src/monitor-location/monitor-location.service.spec.ts
@@ -1,0 +1,24 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+
+import { MonitorLocationService } from './monitor-location.service';
+
+describe('-- Monitor Locations Service --', () => {
+  let monitorLocationService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [MonitorLocationService, ConfigService],
+    }).compile();
+
+    monitorLocationService = module.get(MonitorLocationService);
+  });
+
+  describe('getMonitorLocations', () => {
+    it('returns static data', async () => {
+      let result = await monitorLocationService.getMonitorLocations();
+
+      expect(result).toEqual('Hello getMonitorLocations!');
+    });
+  });
+});

--- a/src/monitor-method/monitor-method.controller.spec.ts
+++ b/src/monitor-method/monitor-method.controller.spec.ts
@@ -1,0 +1,55 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+
+import { MonitorMethodMap } from '../maps/monitor-method.map';
+import { MonitorMethodController } from './monitor-method.controller';
+import { MonitorMethodRepository } from './monitor-method.repository';
+import { MonitorMethodService } from './monitor-method.service';
+import { MonitorMethodDTO } from '../dtos/monitor-method.dto';
+
+const mockConfigService = () => ({
+  get: jest.fn(),
+});
+
+describe('-- Monitor Method Controller --', () => {
+  let monitorMethodController: MonitorMethodController;
+  let monitorMethodService: MonitorMethodService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [MonitorMethodController],
+      providers: [
+        MonitorMethodMap,
+        MonitorMethodService,
+        MonitorMethodRepository,
+        {
+          provide: ConfigService,
+          useFactory: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    monitorMethodController = module.get(MonitorMethodController);
+    monitorMethodService = module.get(MonitorMethodService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('* getMonitorMethods', () => {
+    it('should return a list of Monitor Methods', async () => {
+      const monLocId = '123';
+      const expectedResult: MonitorMethodDTO[] = [];
+
+      const serviceSpy = jest
+        .spyOn(monitorMethodService, 'getMonitorMethods')
+        .mockResolvedValue(expectedResult);
+
+      const result = await monitorMethodController.getUnits(monLocId);
+
+      expect(serviceSpy).toHaveBeenCalledWith(monLocId);
+      expect(result).toBe(expectedResult);
+    });
+  });
+});

--- a/src/monitor-method/monitor-method.service.spec.ts
+++ b/src/monitor-method/monitor-method.service.spec.ts
@@ -1,0 +1,50 @@
+import { Test } from '@nestjs/testing';
+
+import { MonitorMethodMap } from '../maps/monitor-method.map';
+import { MonitorMethodRepository } from './monitor-method.repository';
+import { MonitorMethodService } from './monitor-method.service';
+
+const mockMonitorMethodRepository = () => ({
+  find: jest.fn(),
+});
+
+const mockMap = () => ({
+  many: jest.fn(),
+});
+
+describe('-- Monitor Method Service --', () => {
+  let monitorMethodService;
+  let monitorMethodRepository;
+  let map;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MonitorMethodService,
+        {
+          provide: MonitorMethodRepository,
+          useFactory: mockMonitorMethodRepository,
+        },
+        { provide: MonitorMethodMap, useFactory: mockMap },
+      ],
+    }).compile();
+
+    monitorMethodService = module.get(MonitorMethodService);
+    monitorMethodRepository = module.get(MonitorMethodRepository);
+    map = module.get(MonitorMethodMap);
+  });
+
+  describe('* getMonitorMethods', () => {
+    it('should return all monitor methods with the specified monLocId', async () => {
+      map.many.mockReturnValue('mockMonitorMethods');
+
+      const monLocId = '123';
+
+      let result = await monitorMethodService.getMonitorMethods(monLocId);
+
+      expect(monitorMethodRepository.find).toHaveBeenCalled();
+      expect(map.many).toHaveBeenCalled();
+      expect(result).toEqual('mockMonitorMethods');
+    });
+  });
+});

--- a/src/monitor-plan/monitor-plan.repository.spec.ts
+++ b/src/monitor-plan/monitor-plan.repository.spec.ts
@@ -1,0 +1,48 @@
+import { Test } from '@nestjs/testing';
+import { SelectQueryBuilder } from 'typeorm';
+
+import { MonitorPlanRepository } from './monitor-plan.repository';
+import { MonitorPlan } from '../entities/monitor-plan.entity';
+
+const mockQueryBuilder = () => ({
+  getMany: jest.fn(),
+  innerJoin: jest.fn(),
+});
+
+describe('-- Monitor Plan Repository --', () => {
+  let monitorPlanRepository;
+  let queryBuilder;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MonitorPlanRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+      ],
+    }).compile();
+
+    monitorPlanRepository = module.get(MonitorPlanRepository);
+    queryBuilder = module.get<SelectQueryBuilder<MonitorPlan>>(
+      SelectQueryBuilder,
+    );
+  });
+
+  describe('* getMonitorPlansByOrisCode', () => {
+    it('calls createQueryBuilder and gets all MonitorPlan data from the repository', async () => {
+      monitorPlanRepository.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(queryBuilder);
+      queryBuilder.innerJoin.mockReturnValue(queryBuilder);
+      queryBuilder.getMany.mockReturnValue('mockMonitorPlan');
+
+      const orisCode = 123;
+
+      const result = await monitorPlanRepository.getMonitorPlansByOrisCode(
+        orisCode,
+      );
+
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(result).toEqual('mockMonitorPlan');
+    });
+  });
+});

--- a/src/monitor-plan/monitor-plan.service.spec.ts
+++ b/src/monitor-plan/monitor-plan.service.spec.ts
@@ -1,0 +1,144 @@
+import { Test } from '@nestjs/testing';
+
+import { MonitorPlanService } from './monitor-plan.service';
+import { MonitorPlanRepository } from './monitor-plan.repository';
+import { MonitorPlanMap } from '../maps/monitor-plan.map';
+import { MonitorLocationRepository } from '../monitor-location/monitor-location.repository';
+import { MonitorLocation } from '../entities/monitor-location.entity';
+import { MonitorPlan } from '../entities/monitor-plan.entity';
+import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
+
+const mockMonitorPlanRepository = () => ({
+  getMonitorPlansByOrisCode: jest.fn(),
+});
+
+const mockMonitorLocationRepository = () => ({
+  getMonitorLocationsByFacId: jest.fn(),
+});
+
+const mockMap = () => ({
+  many: jest.fn(),
+});
+
+let monitorPlanEntity: MonitorPlan = new MonitorPlan();
+monitorPlanEntity.id = '123';
+monitorPlanEntity.facId = 3;
+monitorPlanEntity.locations = [];
+
+let monitorLocationEntity1: MonitorLocation = new MonitorLocation();
+monitorLocationEntity1.id = '5';
+monitorLocationEntity1.plans = [monitorPlanEntity];
+monitorLocationEntity1.plans[0].id = '123';
+
+let monitorLocationEntity2: MonitorLocation = new MonitorLocation();
+monitorLocationEntity2.id = '10';
+monitorLocationEntity2.plans = [];
+
+describe('-- Monitor Plan Service --', () => {
+  let monitorPlanService;
+  let monitorPlanRepository;
+  let monitorLocationRepository;
+  let map;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MonitorPlanService,
+        {
+          provide: MonitorPlanRepository,
+          useFactory: mockMonitorPlanRepository,
+        },
+        {
+          provide: MonitorLocationRepository,
+          useFactory: mockMonitorLocationRepository,
+        },
+        { provide: MonitorPlanMap, useFactory: mockMap },
+      ],
+    }).compile();
+
+    monitorPlanService = module.get(MonitorPlanService);
+    monitorPlanRepository = module.get(MonitorPlanRepository);
+
+    monitorLocationRepository = module.get(MonitorLocationRepository);
+
+    map = module.get(MonitorPlanMap);
+  });
+
+  describe('* getConfigurations', () => {
+    it('should return all monitor plan configuration data for the specified oris code', async () => {
+      monitorPlanRepository.getMonitorPlansByOrisCode.mockResolvedValue([
+        monitorPlanEntity,
+      ]);
+      monitorLocationRepository.getMonitorLocationsByFacId.mockResolvedValue([
+        monitorLocationEntity1,
+        monitorLocationEntity2,
+      ]);
+
+      map.many.mockReturnValue(['location 1', 'location 2']);
+
+      const orisCode = 7;
+
+      let result = await monitorPlanService.getConfigurations(orisCode);
+
+      expect(
+        monitorPlanRepository.getMonitorPlansByOrisCode,
+      ).toHaveBeenCalledWith(orisCode);
+      expect(
+        monitorLocationRepository.getMonitorLocationsByFacId,
+      ).toHaveBeenCalledWith(monitorPlanEntity.facId);
+      expect(map.many).toHaveBeenCalled();
+      expect(result).toEqual(['location 1', 'location 2']);
+    });
+
+    it('should return all sorted monitor plan configuration data for the specified oris code', async () => {
+      let monitorPlanDTO1: MonitorPlanDTO = new MonitorPlanDTO();
+      monitorPlanDTO1.id = '1';
+      monitorPlanDTO1.name = 'monitorPlan1';
+      monitorPlanDTO1.locations = [];
+      monitorPlanDTO1.links = [];
+
+      let monitorPlanDTO2: MonitorPlanDTO = new MonitorPlanDTO();
+      monitorPlanDTO2.id = '2';
+      monitorPlanDTO2.name = 'monitorPlan2';
+      monitorPlanDTO2.locations = [];
+      monitorPlanDTO2.links = [];
+
+      let monitorPlanDTO3: MonitorPlanDTO = new MonitorPlanDTO();
+      monitorPlanDTO3.id = '3';
+      monitorPlanDTO3.name = 'monitorPlan3';
+      monitorPlanDTO3.locations = [];
+      monitorPlanDTO3.links = [];
+
+      monitorPlanRepository.getMonitorPlansByOrisCode.mockResolvedValue([
+        monitorPlanEntity,
+      ]);
+      monitorLocationRepository.getMonitorLocationsByFacId.mockResolvedValue([
+        monitorLocationEntity1,
+        monitorLocationEntity2,
+      ]);
+
+      map.many.mockReturnValue([
+        monitorPlanDTO3,
+        monitorPlanDTO1,
+        monitorPlanDTO2,
+      ]);
+
+      const orisCode = 7;
+
+      let result = await monitorPlanService.getConfigurations(orisCode);
+
+      expect(
+        monitorPlanRepository.getMonitorPlansByOrisCode,
+      ).toHaveBeenCalledWith(orisCode);
+      expect(
+        monitorLocationRepository.getMonitorLocationsByFacId,
+      ).toHaveBeenCalledWith(monitorPlanEntity.facId);
+      expect(map.many).toHaveBeenCalled();
+      expect(result).toEqual([
+        monitorPlanDTO1,
+        monitorPlanDTO2,
+        monitorPlanDTO3,
+      ]);
+    });
+  });
+});

--- a/src/supplemental-methods/supplemental-methods.controller.spec.ts
+++ b/src/supplemental-methods/supplemental-methods.controller.spec.ts
@@ -1,0 +1,55 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+
+import { MatsMethodDataDTO } from '../dtos/mats-method-data.dto';
+import { MatsMethodMap } from '../maps/mats-method-data.map';
+import { SupplementalMethodsController } from './supplemental-methods.controller';
+import { MatsMethodRepository } from './supplemental-methods.repository';
+import { SupplementalMethodsService } from './supplemental-methods.service';
+
+const mockConfigService = () => ({
+  get: jest.fn(),
+});
+
+describe('-- Supplemental Methods Controller --', () => {
+  let supplementalMethodsController: SupplementalMethodsController;
+  let supplementalMethodsService: SupplementalMethodsService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [SupplementalMethodsController],
+      providers: [
+        MatsMethodMap,
+        SupplementalMethodsService,
+        MatsMethodRepository,
+        {
+          provide: ConfigService,
+          useFactory: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    supplementalMethodsController = module.get(SupplementalMethodsController);
+    supplementalMethodsService = module.get(SupplementalMethodsService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('* getsSupplementalMethods', () => {
+    it('should return a list of Supplemental Methods', async () => {
+      const monLocId = '123';
+      const expectedResult: MatsMethodDataDTO[] = [];
+
+      const serviceSpy = jest
+        .spyOn(supplementalMethodsService, 'getMatsMethods')
+        .mockResolvedValue(expectedResult);
+
+      const result = await supplementalMethodsController.getUnits(monLocId);
+
+      expect(serviceSpy).toHaveBeenCalledWith(monLocId);
+      expect(result).toBe(expectedResult);
+    });
+  });
+});

--- a/src/supplemental-methods/supplemental-methods.controller.ts
+++ b/src/supplemental-methods/supplemental-methods.controller.ts
@@ -16,7 +16,7 @@ import {
   
   @ApiTags('Supplemental Methods')
   @Controller()
-  export class supplementalMethodsController {
+  export class SupplementalMethodsController {
     constructor(
       private service: SupplementalMethodsService,
     ) {}

--- a/src/supplemental-methods/supplemental-methods.module.ts
+++ b/src/supplemental-methods/supplemental-methods.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { supplementalMethodsController } from './supplemental-methods.controller';
+import { SupplementalMethodsController } from './supplemental-methods.controller';
 import { SupplementalMethodsService } from './supplemental-methods.service';
 import { MatsMethodRepository } from './supplemental-methods.repository';
 
@@ -11,7 +11,7 @@ import { MatsMethodMap } from '../maps/mats-method-data.map';
   imports: [
     TypeOrmModule.forFeature([MatsMethodRepository]),
   ],
-  controllers: [supplementalMethodsController],
+  controllers: [SupplementalMethodsController],
   providers: [
     MatsMethodMap,
     SupplementalMethodsService, 

--- a/src/supplemental-methods/supplemental-methods.service.spec.ts
+++ b/src/supplemental-methods/supplemental-methods.service.spec.ts
@@ -1,0 +1,51 @@
+import { Test } from '@nestjs/testing';
+
+import { MatsMethodMap } from '../maps/mats-method-data.map';
+import { MatsMethodRepository } from './supplemental-methods.repository';
+import { SupplementalMethodsService } from './supplemental-methods.service';
+
+const mockMatsMethodRepository = () => ({
+  find: jest.fn(),
+});
+
+const mockMap = () => ({
+  many: jest.fn(),
+});
+
+describe('-- Supplemental Methods Service --', () => {
+  let supplementalMethodsService;
+  let matsMethodRepository;
+  let map;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        SupplementalMethodsService,
+        {
+          provide: MatsMethodRepository,
+          useFactory: mockMatsMethodRepository,
+        },
+        { provide: MatsMethodMap, useFactory: mockMap },
+      ],
+    }).compile();
+
+    supplementalMethodsService = module.get(SupplementalMethodsService);
+    matsMethodRepository = module.get(MatsMethodRepository);
+
+    map = module.get(MatsMethodMap);
+  });
+
+  describe('* getMatsMethods', () => {
+    it('should return all the supplemental methods with the specified monLocId', async () => {
+      map.many.mockReturnValue('mockSupplementalMethods');
+
+      const monLocId = '123';
+
+      let result = await supplementalMethodsService.getMatsMethods(monLocId);
+
+      expect(matsMethodRepository.find).toHaveBeenCalled();
+      expect(map.many).toHaveBeenCalled();
+      expect(result).toEqual('mockSupplementalMethods');
+    });
+  });
+});

--- a/test-report.xml
+++ b/test-report.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<testExecutions version="1">
-  <file path="C:\Projects\US-EPA-CAMD\easey-monitor-plan-api\src\monitor-plan\monitor-plan.controller.spec.ts">
-    <testCase name="-- Monitor Plan Controller -- * getMonitorPlans should return a list of Monitor Plans" duration="2"/>
-  </file>
-</testExecutions>


### PR DESCRIPTION
## Pull Request

```
Updated unit tests to reach at least 70% code coverage

- Estimated SonarCloud Coverage: 72%
- 100% coverage on Controller, Service, and Repository for monitor-plan, monitor-location, monitor-method, and supplemental-methods
- gitignore: test-report.xml
- Capitalized class name of supplemental methods controller and updated name within module

Linked to ticket #647 (Address unit test coverage for Monitoring Plan API)
```
