### PR TITLE
Feature/2358 reset mp to needs eval status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,5 @@ test-report.xml
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
-!.vscode/extensions.json

--- a/src/analyzer-range-workspace/analyzer-range.controller.ts
+++ b/src/analyzer-range-workspace/analyzer-range.controller.ts
@@ -7,7 +7,12 @@ import {
   Put,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiSecurity, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiSecurity,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { UpdateAnalyzerRangeDTO } from '../dtos/analyzer-range-update.dto';
 import { AnalyzerRangeDTO } from '../dtos/analyzer-range.dto';
 import { AnalyzerRangeWorkspaceService } from './analyzer-range.service';
@@ -56,7 +61,12 @@ export class AnalyzerRangeWorkspaceController {
       componentRecordId: componentRecordId,
       payload: payload,
     });
-    return this.service.createAnalyzerRange(componentRecordId, payload);
+    return this.service.createAnalyzerRange(
+      componentRecordId,
+      payload,
+      locationId,
+      userId,
+    );
   }
 
   @Put(':analyzerRangeId')
@@ -79,6 +89,11 @@ export class AnalyzerRangeWorkspaceController {
       analyzerRangeId: analyzerRangeId,
       payload: payload,
     });
-    return this.service.updateAnalyzerRangd(analyzerRangeId, payload);
+    return this.service.updateAnalyzerRangd(
+      analyzerRangeId,
+      payload,
+      locationId,
+      userId,
+    );
   }
 }

--- a/src/analyzer-range-workspace/analyzer-range.module.ts
+++ b/src/analyzer-range-workspace/analyzer-range.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { AnalyzerRangeWorkspaceController } from './analyzer-range.controller';
 import { AnalyzerRangeWorkspaceService } from './analyzer-range.service';
 import { AnalyzerRangeWorkspaceRepository } from './analyzer-range.repository';
 import { AnalyzerRangeMap } from '../maps/analyzer-range.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AnalyzerRangeWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [AnalyzerRangeWorkspaceController],
   providers: [AnalyzerRangeWorkspaceService, AnalyzerRangeMap],

--- a/src/analyzer-range-workspace/analyzer-range.service.ts
+++ b/src/analyzer-range-workspace/analyzer-range.service.ts
@@ -10,6 +10,7 @@ import { AnalyzerRangeMap } from '../maps/analyzer-range.map';
 
 import { AnalyzerRangeWorkspaceRepository } from './analyzer-range.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class AnalyzerRangeWorkspaceService {
@@ -18,6 +19,7 @@ export class AnalyzerRangeWorkspaceService {
     private repository: AnalyzerRangeWorkspaceRepository,
     private map: AnalyzerRangeMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getAnalyzerRanges(compId: string): Promise<AnalyzerRangeDTO[]> {
@@ -56,6 +58,7 @@ export class AnalyzerRangeWorkspaceService {
     });
 
     const result = await this.repository.save(analyzerRange);
+    await this.mpService.resetToNeedsEvaluation('locationId', 'userId');
     return this.map.one(result);
   }
 
@@ -73,7 +76,7 @@ export class AnalyzerRangeWorkspaceService {
     analyzerRange.endHour = payload.endHour;
 
     const result = await this.repository.save(analyzerRange);
-
+    await this.mpService.resetToNeedsEvaluation('locationId', 'userId');
     return this.map.one(result);
   }
 }

--- a/src/analyzer-range-workspace/analyzer-range.service.ts
+++ b/src/analyzer-range-workspace/analyzer-range.service.ts
@@ -42,6 +42,8 @@ export class AnalyzerRangeWorkspaceService {
   async createAnalyzerRange(
     componentRecordId: string,
     payload: UpdateAnalyzerRangeDTO,
+    locationId: string,
+    userId: string,
   ): Promise<AnalyzerRangeDTO> {
     const analyzerRange = this.repository.create({
       id: uuid(),
@@ -58,13 +60,15 @@ export class AnalyzerRangeWorkspaceService {
     });
 
     const result = await this.repository.save(analyzerRange);
-    await this.mpService.resetToNeedsEvaluation('locationId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 
   async updateAnalyzerRangd(
     analyzerRangeId: string,
     payload: UpdateAnalyzerRangeDTO,
+    locationId: string,
+    userId: string,
   ): Promise<AnalyzerRangeDTO> {
     const analyzerRange = await this.getAnalyzerRange(analyzerRangeId);
 
@@ -76,7 +80,7 @@ export class AnalyzerRangeWorkspaceService {
     analyzerRange.endHour = payload.endHour;
 
     const result = await this.repository.save(analyzerRange);
-    await this.mpService.resetToNeedsEvaluation('locationId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 }

--- a/src/duct-waf-workspace/duct-waf.module.ts
+++ b/src/duct-waf-workspace/duct-waf.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,9 +6,14 @@ import { DuctWafWorkspaceController } from './duct-waf.controller';
 import { DuctWafWorkspaceService } from './duct-waf.service';
 import { DuctWafWorkspaceRepository } from './duct-waf.repository';
 import { DuctWafMap } from '../maps/duct-waf.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DuctWafWorkspaceRepository]), HttpModule],
+  imports: [
+    TypeOrmModule.forFeature([DuctWafWorkspaceRepository]),
+    HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
+  ],
   controllers: [DuctWafWorkspaceController],
   providers: [DuctWafWorkspaceService, DuctWafMap],
   exports: [TypeOrmModule, DuctWafWorkspaceService, DuctWafMap],

--- a/src/duct-waf-workspace/duct-waf.service.ts
+++ b/src/duct-waf-workspace/duct-waf.service.ts
@@ -57,8 +57,7 @@ export class DuctWafWorkspaceService {
       ductDepth: payload.ductDepth,
       wafEndDate: payload.wafEndDate,
       wafEndHour: payload.wafEndHour,
-      // TODO - remove slice when userId constraints are fixed in the db
-      userId: userId.slice(0, 7),
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -89,8 +88,7 @@ export class DuctWafWorkspaceService {
     ductWaf.ductDepth = payload.ductDepth;
     ductWaf.wafEndDate = payload.wafEndDate;
     ductWaf.wafEndHour = payload.wafEndHour;
-    // TODO - remove slice when userId constraints are fixed in the db
-    ductWaf.userId = userId.slice(0, 7);
+    ductWaf.userId = userId;
     ductWaf.updateDate = new Date(Date.now());
 
     await this.repository.save(ductWaf);

--- a/src/duct-waf-workspace/duct-waf.service.ts
+++ b/src/duct-waf-workspace/duct-waf.service.ts
@@ -7,6 +7,7 @@ import { DuctWafDTO } from '../dtos/duct-waf.dto';
 import { DuctWafMap } from '../maps/duct-waf.map';
 import { DuctWafWorkspaceRepository } from './duct-waf.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class DuctWafWorkspaceService {
@@ -15,6 +16,7 @@ export class DuctWafWorkspaceService {
     private repository: DuctWafWorkspaceRepository,
     private map: DuctWafMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getDuctWafs(locationId: string): Promise<DuctWafDTO[]> {
@@ -26,7 +28,9 @@ export class DuctWafWorkspaceService {
     const result = await this.repository.findOne(id);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'Duct Waf Not Found', true, { id: id });
+      this.Logger.error(NotFoundException, 'Duct Waf Not Found', true, {
+        id: id,
+      });
     }
 
     return this.map.one(result);
@@ -60,7 +64,7 @@ export class DuctWafWorkspaceService {
     });
 
     const result = await this.repository.save(ductWaf);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 
@@ -90,7 +94,7 @@ export class DuctWafWorkspaceService {
     ductWaf.updateDate = new Date(Date.now());
 
     await this.repository.save(ductWaf);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getDuctWaf(ductWafId);
   }
 }

--- a/src/lee-qualification-workspace/lee-qualification.module.ts
+++ b/src/lee-qualification-workspace/lee-qualification.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { LEEQualificationWorkspaceController } from './lee-qualification.control
 import { LEEQualificationWorkspaceService } from './lee-qualification.service';
 import { LEEQualificationWorkspaceRepository } from './lee-qualification.repository';
 import { LEEQualificationMap } from '../maps/lee-qualification.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([LEEQualificationWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [LEEQualificationWorkspaceController],
   providers: [LEEQualificationWorkspaceService, LEEQualificationMap],

--- a/src/lee-qualification-workspace/lee-qualification.service.ts
+++ b/src/lee-qualification-workspace/lee-qualification.service.ts
@@ -7,6 +7,7 @@ import { LEEQualificationMap } from '../maps/lee-qualification.map';
 import { UpdateLEEQualificationDTO } from '../dtos/lee-qualification-update.dto';
 
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class LEEQualificationWorkspaceService {
@@ -15,7 +16,8 @@ export class LEEQualificationWorkspaceService {
     private repository: LEEQualificationWorkspaceRepository,
     private map: LEEQualificationMap,
     private Logger: Logger,
-  ) { }
+    private readonly mpService: MonitorPlanWorkspaceService,
+  ) {}
 
   async getLEEQualifications(
     locId: string,
@@ -36,11 +38,16 @@ export class LEEQualificationWorkspaceService {
       pctQualId,
     );
     if (!result) {
-      this.Logger.error(NotFoundException, 'LEE Qualification Not Found', true,{
-        locId: locId,
-        qualId: qualId,
-        pctQualId: pctQualId,
-      });
+      this.Logger.error(
+        NotFoundException,
+        'LEE Qualification Not Found',
+        true,
+        {
+          locId: locId,
+          qualId: qualId,
+          pctQualId: pctQualId,
+        },
+      );
     }
     return this.map.one(result);
   }
@@ -67,7 +74,7 @@ export class LEEQualificationWorkspaceService {
     });
 
     const result = await this.repository.save(load);
-
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(result);
   }
 
@@ -92,7 +99,8 @@ export class LEEQualificationWorkspaceService {
     leeQual.userId = 'testuser';
     leeQual.updateDate = new Date(Date.now());
 
-    await this.repository.save(leeQual);
-    return this.getLEEQualification(locId, qualId, pctQualId);
+    const result = await this.repository.save(leeQual);
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
+    return this.map.one(result);
   }
 }

--- a/src/lee-qualification-workspace/lee-qualification.service.ts
+++ b/src/lee-qualification-workspace/lee-qualification.service.ts
@@ -68,7 +68,7 @@ export class LEEQualificationWorkspaceService {
       applicableEmissionStandard: payload.applicableEmissionStandard,
       unitsOfStandard: payload.unitsOfStandard,
       percentageOfEmissionStandard: payload.percentageOfEmissionStandard,
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -96,7 +96,7 @@ export class LEEQualificationWorkspaceService {
     leeQual.applicableEmissionStandard = payload.applicableEmissionStandard;
     leeQual.unitsOfStandard = payload.unitsOfStandard;
     leeQual.percentageOfEmissionStandard = payload.percentageOfEmissionStandard;
-    leeQual.userId = 'testuser';
+    leeQual.userId = userId;
     leeQual.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(leeQual);

--- a/src/lme-qualification-workspace/lme-qualification.module.ts
+++ b/src/lme-qualification-workspace/lme-qualification.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { LMEQualificationWorkspaceController } from './lme-qualification.control
 import { LMEQualificationWorkspaceService } from './lme-qualification.service';
 import { LMEQualificationWorkspaceRepository } from './lme-qualification.repository';
 import { LMEQualificationMap } from '../maps/lme-qualification.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([LMEQualificationWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [LMEQualificationWorkspaceController],
   providers: [LMEQualificationWorkspaceService, LMEQualificationMap],

--- a/src/lme-qualification-workspace/lme-qualification.service.ts
+++ b/src/lme-qualification-workspace/lme-qualification.service.ts
@@ -65,7 +65,7 @@ export class LMEQualificationWorkspaceService {
       operatingHours: payload.operatingHours,
       so2Tons: payload.so2Tons,
       noxTons: payload.noxTons,
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -89,7 +89,7 @@ export class LMEQualificationWorkspaceService {
     lmeQual.operatingHours = payload.operatingHours;
     lmeQual.so2Tons = payload.so2Tons;
     lmeQual.noxTons = payload.noxTons;
-    lmeQual.userId = 'testuser';
+    lmeQual.userId = userId;
     lmeQual.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(lmeQual);

--- a/src/mats-method-workspace/mats-method.controller.ts
+++ b/src/mats-method-workspace/mats-method.controller.ts
@@ -7,7 +7,12 @@ import {
   Put,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOkResponse, ApiTags, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiTags,
+  ApiSecurity,
+} from '@nestjs/swagger';
 
 import { MatsMethodWorkspaceService } from './mats-method.service';
 import { MatsMethodDTO } from '../dtos/mats-method.dto';
@@ -53,7 +58,7 @@ export class MatsMethodWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.createMethod(locationId, payload);
+    return this.service.createMethod(locationId, payload, userId);
   }
 
   @Put(':methodId')
@@ -75,6 +80,6 @@ export class MatsMethodWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.updateMethod(methodId, locationId, payload);
+    return this.service.updateMethod(methodId, locationId, payload, userId);
   }
 }

--- a/src/mats-method-workspace/mats-method.module.ts
+++ b/src/mats-method-workspace/mats-method.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { MatsMethodWorkspaceController } from './mats-method.controller';
 import { MatsMethodWorkspaceService } from './mats-method.service';
 import { MatsMethodWorkspaceRepository } from './mats-method.repository';
 import { MatsMethodMap } from '../maps/mats-method.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MatsMethodWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MatsMethodWorkspaceController],
   providers: [MatsMethodWorkspaceService, MatsMethodMap],

--- a/src/mats-method-workspace/mats-method.service.ts
+++ b/src/mats-method-workspace/mats-method.service.ts
@@ -39,6 +39,7 @@ export class MatsMethodWorkspaceService {
   async createMethod(
     locationId: string,
     payload: UpdateMatsMethodDTO,
+    userId: string,
   ): Promise<MatsMethodDTO> {
     const method = this.repository.create({
       id: uuid(),
@@ -52,13 +53,13 @@ export class MatsMethodWorkspaceService {
       endHour: payload.endHour,
 
       // TODO: userId to be determined
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     const result = await this.repository.save(method);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
 
     return this.map.one(result);
   }
@@ -67,6 +68,7 @@ export class MatsMethodWorkspaceService {
     methodId: string,
     locationId: string,
     payload: UpdateMatsMethodDTO,
+    userId: string,
   ): Promise<MatsMethodDTO> {
     const method = await this.getMethod(methodId);
 
@@ -77,11 +79,11 @@ export class MatsMethodWorkspaceService {
     method.endHour = payload.endHour;
 
     // TODO: userId to be determined
-    method.userId = 'testuser';
+    method.userId = userId;
     method.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(method);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 }

--- a/src/mats-method-workspace/mats-method.service.ts
+++ b/src/mats-method-workspace/mats-method.service.ts
@@ -7,6 +7,7 @@ import { MatsMethodMap } from '../maps/mats-method.map';
 import { MatsMethodDTO } from '../dtos/mats-method.dto';
 import { UpdateMatsMethodDTO } from '../dtos/mats-method-update.dto';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class MatsMethodWorkspaceService {
@@ -15,6 +16,7 @@ export class MatsMethodWorkspaceService {
     private repository: MatsMethodWorkspaceRepository,
     private map: MatsMethodMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getMethods(locationId: string): Promise<MatsMethodDTO[]> {
@@ -56,6 +58,8 @@ export class MatsMethodWorkspaceService {
     });
 
     const result = await this.repository.save(method);
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+
     return this.map.one(result);
   }
 
@@ -77,6 +81,7 @@ export class MatsMethodWorkspaceService {
     method.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(method);
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.map.one(result);
   }
 }

--- a/src/monitor-attribute-workspace/monitor-attribute.module.ts
+++ b/src/monitor-attribute-workspace/monitor-attribute.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { MonitorAttributeWorkspaceController } from './monitor-attribute.control
 import { MonitorAttributeWorkspaceService } from './monitor-attribute.service';
 import { MonitorAttributeWorkspaceRepository } from './monitor-attribute.repository';
 import { MonitorAttributeMap } from '../maps/montitor-attribute.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MonitorAttributeWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorAttributeWorkspaceController],
   providers: [MonitorAttributeWorkspaceService, MonitorAttributeMap],

--- a/src/monitor-attribute-workspace/monitor-attribute.service.ts
+++ b/src/monitor-attribute-workspace/monitor-attribute.service.ts
@@ -7,6 +7,7 @@ import { UpdateMonitorAttributeDTO } from '../dtos/monitor-attribute-update.dto'
 import { MonitorAttributeDTO } from '../dtos/monitor-attribute.dto';
 import { MonitorAttributeWorkspaceRepository } from './monitor-attribute.repository';
 import { MonitorAttributeMap } from '../maps/montitor-attribute.map';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class MonitorAttributeWorkspaceService {
@@ -15,6 +16,7 @@ export class MonitorAttributeWorkspaceService {
     private readonly repository: MonitorAttributeWorkspaceRepository,
     private readonly map: MonitorAttributeMap,
     private readonly logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getAttributes(locationId: string): Promise<MonitorAttributeDTO[]> {
@@ -67,7 +69,7 @@ export class MonitorAttributeWorkspaceService {
     });
 
     const result = await this.repository.save(attribute);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getAttribute(locationId, result.id);
   }
 
@@ -93,7 +95,7 @@ export class MonitorAttributeWorkspaceService {
     attribute.updateDate = new Date(Date.now());
 
     await this.repository.save(attribute);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getAttribute(locationId, id);
   }
 }

--- a/src/monitor-attribute-workspace/monitor-attribute.service.ts
+++ b/src/monitor-attribute-workspace/monitor-attribute.service.ts
@@ -63,7 +63,7 @@ export class MonitorAttributeWorkspaceService {
       crossAreaStackExit: payload.crossAreaStackExit,
       beginDate: payload.beginDate,
       endDate: payload.endDate,
-      userId: userId.slice(0, 8),
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -91,7 +91,7 @@ export class MonitorAttributeWorkspaceService {
     attribute.crossAreaStackExit = payload.crossAreaStackExit;
     attribute.beginDate = payload.beginDate;
     attribute.endDate = payload.endDate;
-    attribute.userId = userId.slice(0, 8);
+    attribute.userId = userId;
     attribute.updateDate = new Date(Date.now());
 
     await this.repository.save(attribute);

--- a/src/monitor-default-workspace/monitor-default.controller.ts
+++ b/src/monitor-default-workspace/monitor-default.controller.ts
@@ -1,4 +1,9 @@
-import { ApiTags, ApiOkResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
 import {
   Get,
   Param,
@@ -56,7 +61,7 @@ export class MonitorDefaultWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.updateDefault(locationId, defaultId, payload);
+    return this.service.updateDefault(locationId, defaultId, payload, userId);
   }
 
   @Post()
@@ -76,6 +81,6 @@ export class MonitorDefaultWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.createDefault(locationId, payload);
+    return this.service.createDefault(locationId, payload, userId);
   }
 }

--- a/src/monitor-default-workspace/monitor-default.module.ts
+++ b/src/monitor-default-workspace/monitor-default.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { MonitorDefaultWorkspaceController } from './monitor-default.controller'
 import { MonitorDefaultWorkspaceService } from './monitor-default.service';
 import { MonitorDefaultWorkspaceRepository } from './monitor-default.repository';
 import { MonitorDefaultMap } from '../maps/monitor-default.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MonitorDefaultWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorDefaultWorkspaceController],
   providers: [MonitorDefaultWorkspaceService, MonitorDefaultMap],

--- a/src/monitor-default-workspace/monitor-default.service.ts
+++ b/src/monitor-default-workspace/monitor-default.service.ts
@@ -7,6 +7,7 @@ import { MonitorDefaultDTO } from '../dtos/monitor-default.dto';
 import { MonitorDefaultMap } from '../maps/monitor-default.map';
 import { UpdateMonitorDefaultDTO } from '../dtos/monitor-default-update.dto';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class MonitorDefaultWorkspaceService {
@@ -15,6 +16,7 @@ export class MonitorDefaultWorkspaceService {
     private repository: MonitorDefaultWorkspaceRepository,
     private map: MonitorDefaultMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getDefaults(locationId: string): Promise<MonitorDefaultDTO[]> {
@@ -29,7 +31,7 @@ export class MonitorDefaultWorkspaceService {
     const result = await this.repository.getDefault(locationId, defaultId);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'Monitor Default Not Found', true,{
+      this.Logger.error(NotFoundException, 'Monitor Default Not Found', true, {
         locationId: locationId,
         defaultId: defaultId,
       });
@@ -63,7 +65,7 @@ export class MonitorDefaultWorkspaceService {
     });
 
     const result = await this.repository.save(monDefault);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.map.one(result);
   }
 
@@ -90,7 +92,7 @@ export class MonitorDefaultWorkspaceService {
     monDefault.updateDate = new Date(Date.now());
 
     await this.repository.save(monDefault);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.getDefault(locationId, defaultId);
   }
 }

--- a/src/monitor-default-workspace/monitor-default.service.ts
+++ b/src/monitor-default-workspace/monitor-default.service.ts
@@ -43,6 +43,7 @@ export class MonitorDefaultWorkspaceService {
   async createDefault(
     locationId: string,
     payload: UpdateMonitorDefaultDTO,
+    userId: string,
   ): Promise<MonitorDefaultDTO> {
     const monDefault = this.repository.create({
       id: uuid(),
@@ -59,13 +60,13 @@ export class MonitorDefaultWorkspaceService {
       beginHour: payload.beginHour,
       endDate: payload.endDate,
       endHour: payload.endHour,
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     const result = await this.repository.save(monDefault);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 
@@ -73,6 +74,7 @@ export class MonitorDefaultWorkspaceService {
     locationId: string,
     defaultId: string,
     payload: UpdateMonitorDefaultDTO,
+    userId: string,
   ): Promise<MonitorDefaultDTO> {
     const monDefault = await this.getDefault(locationId, defaultId);
 
@@ -88,11 +90,11 @@ export class MonitorDefaultWorkspaceService {
     monDefault.beginHour = payload.beginHour;
     monDefault.endDate = payload.endDate;
     monDefault.endHour = payload.endHour;
-    monDefault.userId = 'testuser';
+    monDefault.userId = userId;
     monDefault.updateDate = new Date(Date.now());
 
     await this.repository.save(monDefault);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getDefault(locationId, defaultId);
   }
 }

--- a/src/monitor-formula-workspace/monitor-formula.module.ts
+++ b/src/monitor-formula-workspace/monitor-formula.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { MonitorFormulaWorkspaceController } from './monitor-formula.controller'
 import { MonitorFormulaWorkspaceService } from './monitor-formula.service';
 import { MonitorFormulaWorkspaceRepository } from './monitor-formula.repository';
 import { MonitorFormulaMap } from '../maps/monitor-formula.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MonitorFormulaWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorFormulaWorkspaceController],
   providers: [MonitorFormulaWorkspaceService, MonitorFormulaMap],

--- a/src/monitor-formula-workspace/monitor-formula.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula.service.ts
@@ -59,7 +59,7 @@ export class MonitorFormulaWorkspaceService {
       beginHour: payload.beginHour,
       endDate: payload.endDate,
       endHour: payload.endHour,
-      userId: userId.slice(0, 8),
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -85,7 +85,7 @@ export class MonitorFormulaWorkspaceService {
     formula.beginHour = payload.beginHour;
     formula.endDate = payload.endDate;
     formula.endHour = payload.endHour;
-    formula.userId = userId.slice(0, 8);
+    formula.userId = userId;
     formula.updateDate = new Date(Date.now());
 
     await this.repository.save(formula);

--- a/src/monitor-load-workspace/monitor-load.controller.ts
+++ b/src/monitor-load-workspace/monitor-load.controller.ts
@@ -1,4 +1,9 @@
-import { ApiTags, ApiOkResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
 import {
   Get,
   Param,
@@ -54,7 +59,7 @@ export class MonitorLoadWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.updateLoad(locationId, spanId, payload);
+    return this.service.updateLoad(locationId, spanId, payload, userId);
   }
 
   @Post()
@@ -75,6 +80,6 @@ export class MonitorLoadWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.createLoad(locationId, payload);
+    return this.service.createLoad(locationId, payload, userId);
   }
 }

--- a/src/monitor-load-workspace/monitor-load.module.ts
+++ b/src/monitor-load-workspace/monitor-load.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { MonitorLoadWorkspaceController } from './monitor-load.controller';
 import { MonitorLoadWorkspaceService } from './monitor-load.service';
 import { MonitorLoadWorkspaceRepository } from './monitor-load.repository';
 import { MonitorLoadMap } from '../maps/monitor-load.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MonitorLoadWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorLoadWorkspaceController],
   providers: [MonitorLoadWorkspaceService, MonitorLoadMap],

--- a/src/monitor-load-workspace/monitor-load.service.ts
+++ b/src/monitor-load-workspace/monitor-load.service.ts
@@ -39,6 +39,7 @@ export class MonitorLoadWorkspaceService {
   async createLoad(
     locationId: string,
     payload: UpdateMonitorLoadDTO,
+    userId: string,
   ): Promise<MonitorLoadDTO> {
     const load = this.repository.create({
       id: uuid(),
@@ -55,13 +56,13 @@ export class MonitorLoadWorkspaceService {
       normalLevelCode: payload.normalLevelCode,
       secondLevelCode: payload.secondLevelCode,
       maximumLoadUnitsOfMeasureCode: payload.maximumLoadUnitsOfMeasureCode,
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     const result = await this.repository.save(load);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 
@@ -69,6 +70,7 @@ export class MonitorLoadWorkspaceService {
     locationId: string,
     loadId: string,
     payload: UpdateMonitorLoadDTO,
+    userId: string,
   ): Promise<MonitorLoadDTO> {
     const load = await this.getLoad(loadId);
 
@@ -84,12 +86,11 @@ export class MonitorLoadWorkspaceService {
     load.normalLevelCode = payload.normalLevelCode;
     load.secondLevelCode = payload.secondLevelCode;
     load.maximumLoadUnitsOfMeasureCode = payload.maximumLoadUnitsOfMeasureCode;
-    // TODO
-    load.userId = 'testuser';
+    load.userId = userId;
     load.updateDate = new Date(Date.now());
 
     await this.repository.save(load);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getLoad(loadId);
   }
 }

--- a/src/monitor-load-workspace/monitor-load.service.ts
+++ b/src/monitor-load-workspace/monitor-load.service.ts
@@ -7,6 +7,7 @@ import { MonitorLoadDTO } from '../dtos/monitor-load.dto';
 import { MonitorLoadMap } from '../maps/monitor-load.map';
 import { MonitorLoadWorkspaceRepository } from './monitor-load.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class MonitorLoadWorkspaceService {
@@ -15,6 +16,7 @@ export class MonitorLoadWorkspaceService {
     private repository: MonitorLoadWorkspaceRepository,
     private map: MonitorLoadMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getLoads(locationId: string): Promise<MonitorLoadDTO[]> {
@@ -26,7 +28,7 @@ export class MonitorLoadWorkspaceService {
     const result = await this.repository.findOne(loadId);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'Monitor Load Not Found', true,{
+      this.Logger.error(NotFoundException, 'Monitor Load Not Found', true, {
         loadId: loadId,
       });
     }
@@ -59,7 +61,7 @@ export class MonitorLoadWorkspaceService {
     });
 
     const result = await this.repository.save(load);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.map.one(result);
   }
 
@@ -87,7 +89,7 @@ export class MonitorLoadWorkspaceService {
     load.updateDate = new Date(Date.now());
 
     await this.repository.save(load);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.getLoad(loadId);
   }
 }

--- a/src/monitor-method-workspace/monitor-method.controller.ts
+++ b/src/monitor-method-workspace/monitor-method.controller.ts
@@ -1,4 +1,9 @@
-import { ApiTags, ApiOkResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
 import {
   Get,
   Put,
@@ -13,6 +18,7 @@ import { MonitorMethodDTO } from '../dtos/monitor-method.dto';
 import { UpdateMonitorMethodDTO } from '../dtos/monitor-method-update.dto';
 import { MonitorMethodWorkspaceService } from './monitor-method.service';
 import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { CurrentUser } from '@us-epa-camd/easey-common/decorators';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -40,8 +46,9 @@ export class MonitorMethodWorkspaceController {
   createMethod(
     @Param('locId') locId: string,
     @Body() payload: UpdateMonitorMethodDTO,
+    @CurrentUser() userId: string,
   ): Promise<MonitorMethodDTO> {
-    return this.service.createMethod(locId, payload);
+    return this.service.createMethod(locId, payload, userId);
   }
 
   @Put(':methodId')
@@ -55,7 +62,8 @@ export class MonitorMethodWorkspaceController {
     @Param('locId') locId: string,
     @Param('methodId') methodId: string,
     @Body() payload: UpdateMonitorMethodDTO,
+    @CurrentUser() userId: string,
   ): Promise<MonitorMethodDTO> {
-    return this.service.updateMethod(methodId, payload);
+    return this.service.updateMethod(methodId, payload, locId, userId);
   }
 }

--- a/src/monitor-method-workspace/monitor-method.module.ts
+++ b/src/monitor-method-workspace/monitor-method.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { MonitorMethodWorkspaceController } from './monitor-method.controller';
 import { MonitorMethodWorkspaceService } from './monitor-method.service';
 import { MonitorMethodWorkspaceRepository } from './monitor-method.repository';
 import { MonitorMethodMap } from '../maps/monitor-method.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MonitorMethodWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorMethodWorkspaceController],
   providers: [MonitorMethodWorkspaceService, MonitorMethodMap],

--- a/src/monitor-method-workspace/monitor-method.service.ts
+++ b/src/monitor-method-workspace/monitor-method.service.ts
@@ -8,6 +8,7 @@ import { MonitorMethodMap } from '../maps/monitor-method.map';
 import { MonitorMethod } from '../entities/workspace/monitor-method.entity';
 import { MonitorMethodWorkspaceRepository } from './monitor-method.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class MonitorMethodWorkspaceService {
@@ -16,6 +17,7 @@ export class MonitorMethodWorkspaceService {
     private repository: MonitorMethodWorkspaceRepository,
     private map: MonitorMethodMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getMethods(locId: string): Promise<MonitorMethodDTO[]> {
@@ -27,7 +29,7 @@ export class MonitorMethodWorkspaceService {
     const result = this.repository.findOne(methodId);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'Monitor Method Not Found', true,{
+      this.Logger.error(NotFoundException, 'Monitor Method Not Found', true, {
         methodId: methodId,
       });
     }
@@ -59,6 +61,7 @@ export class MonitorMethodWorkspaceService {
     });
 
     const entity = await this.repository.save(monMethod);
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.map.one(entity);
   }
 
@@ -83,6 +86,7 @@ export class MonitorMethodWorkspaceService {
     method.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(method);
+    await this.mpService.resetToNeedsEvaluation('locationId', 'userId');
     return this.map.one(result);
   }
 }

--- a/src/monitor-method-workspace/monitor-method.service.ts
+++ b/src/monitor-method-workspace/monitor-method.service.ts
@@ -40,6 +40,7 @@ export class MonitorMethodWorkspaceService {
   async createMethod(
     locationId: string,
     payload: UpdateMonitorMethodDTO,
+    userId: string,
   ): Promise<MonitorMethodDTO> {
     const monMethod = this.repository.create({
       id: uuid(),
@@ -52,22 +53,21 @@ export class MonitorMethodWorkspaceService {
       beginHour: payload.beginHour,
       endDate: payload.endDate,
       endHour: payload.endHour,
-      // TODO: this needs to be the actual user that is logged in
-      // how are we going to get this from CDX as this is an id NOT a username
-      userId: 'testuser',
-
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     const entity = await this.repository.save(monMethod);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(entity);
   }
 
   async updateMethod(
     methodId: string,
     payload: UpdateMonitorMethodDTO,
+    locationId: string,
+    userId: string,
   ): Promise<MonitorMethodDTO> {
     const method = await this.getMethod(methodId);
 
@@ -79,14 +79,11 @@ export class MonitorMethodWorkspaceService {
     method.beginHour = payload.beginHour;
     method.endDate = payload.endDate;
     method.endHour = payload.endHour;
-
-    // TODO: this needs to be the actual user that is logged in
-    // how are we going to get this from CDX as this is an id NOT a username
-    method.userId = 'testuser';
+    method.userId = userId;
     method.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(method);
-    await this.mpService.resetToNeedsEvaluation('locationId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 }

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -63,11 +63,6 @@ export class MonitorPlanWorkspaceController {
     return this.service.getConfigurations(orisCode);
   }
 
-  // @Get(':planId')
-  // getPlan(@Param('planId') planId: string) {
-  //   return this.service.getMonitorPlan(planId);
-  // }
-
   @Get(':planId/evaluation-report')
   @ApiOkResponse({
     description: 'Retrieves facility information and evaluation results',

--- a/src/monitor-plan-workspace/monitor-plan.module.ts
+++ b/src/monitor-plan-workspace/monitor-plan.module.ts
@@ -53,5 +53,6 @@ import { MonitorPlanMap } from '../maps/monitor-plan.map';
   ],
   controllers: [MonitorPlanWorkspaceController],
   providers: [MonitorPlanWorkspaceService, MonitorPlanMap],
+  exports: [TypeOrmModule, MonitorPlanWorkspaceService, MonitorPlanMap],
 })
 export class MonitorPlanWorkspaceModule {}

--- a/src/monitor-plan-workspace/monitor-plan.repository.ts
+++ b/src/monitor-plan-workspace/monitor-plan.repository.ts
@@ -41,13 +41,36 @@ export class MonitorPlanWorkspaceRepository extends Repository<MonitorPlan> {
       .getOne();
   }
 
+  async getActivePlanByLocation(locId: string): Promise<MonitorPlan> {
+    return this.createQueryBuilder('plan')
+      .innerJoinAndSelect('plan.locations', 'locations')
+      .where('locations.id = :locId', { locId })
+      .getOne();
+  }
+
   async resetToNeedsEvaluation(planId: string, userId: string) {
     try {
       const currDate = new Date(Date.now());
       const needsEvalStatus = 'EVAL';
+      const updatedStatusFlag = 'Y';
+      const needsEvalFlag = 'Y';
       await this.query(
-        'UPDATE camdecmpswks.monitor_plan SET eval_status_cd = $1, update_date = $2, userid = $3 WHERE mon_plan_id = $4',
-        [needsEvalStatus, currDate, userId, planId],
+        'UPDATE camdecmpswks.monitor_plan SET ' +
+          'eval_status_cd = $1, ' +
+          'last_updated = $2, ' +
+          'update_date = $2,' +
+          'updated_status_flg = $3, ' +
+          'needs_eval_flg = $4, ' +
+          'userid = $5 ' +
+          'WHERE mon_plan_id = $6',
+        [
+          needsEvalStatus,
+          currDate,
+          updatedStatusFlag,
+          needsEvalFlag,
+          userId,
+          planId,
+        ],
       );
       return this.findOne({ id: planId });
     } catch (error) {

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -97,20 +97,21 @@ export class MonitorPlanWorkspaceService {
   }
 
   async resetToNeedsEvaluation(planId: string, userId: string): Promise<void> {
-    const result = await this.repository.resetToNeedsEvaluation(planId, userId);
-    console.log('reset result:', result);
-    if (result) {
-      console.log(
-        'Monitor plan with ID: ' +
-          planId +
-          ' successfully reset to Needs Evaluation status.',
-      );
-    } else {
-      console.log(
-        'Failed to reset plan with ID: ' +
-          planId +
-          ' to Needs Evaluation status.',
-      );
-    }
+    // const result = await this.repository.resetToNeedsEvaluation(planId, userId);
+    // console.log('reset result:', result);
+    // if (result) {
+    //   console.log(
+    //     'Monitor plan with ID: ' +
+    //       planId +
+    //       ' successfully reset to Needs Evaluation status.',
+    //   );
+    // } else {
+    //   console.log(
+    //     'Failed to reset plan with ID: ' +
+    //       planId +
+    //       ' to Needs Evaluation status.',
+    //   );
+    // }
+    console.log('resetToNeedsEvaluation called');
   }
 }

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -96,9 +96,12 @@ export class MonitorPlanWorkspaceService {
     return mpEvalReport;
   }
 
-  async resetToNeedsEvaluation(planId: string, userId: string): Promise<void> {
+  async resetToNeedsEvaluation(locId: string, userId: string): Promise<void> {
+    // get monitor plan by location ID
+
+    // update plan's eval status to EVAL
     // const result = await this.repository.resetToNeedsEvaluation(planId, userId);
-    // console.log('reset result:', result);
+
     // if (result) {
     //   console.log(
     //     'Monitor plan with ID: ' +

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -95,4 +95,22 @@ export class MonitorPlanWorkspaceService {
 
     return mpEvalReport;
   }
+
+  async resetToNeedsEvaluation(planId: string, userId: string): Promise<void> {
+    const result = await this.repository.resetToNeedsEvaluation(planId, userId);
+    console.log('reset result:', result);
+    if (result) {
+      console.log(
+        'Monitor plan with ID: ' +
+          planId +
+          ' successfully reset to Needs Evaluation status.',
+      );
+    } else {
+      console.log(
+        'Failed to reset plan with ID: ' +
+          planId +
+          ' to Needs Evaluation status.',
+      );
+    }
+  }
 }

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -97,24 +97,9 @@ export class MonitorPlanWorkspaceService {
   }
 
   async resetToNeedsEvaluation(locId: string, userId: string): Promise<void> {
-    // get monitor plan by location ID
+    const plan = await this.repository.getActivePlanByLocation(locId);
+    const planId = plan.id;
 
-    // update plan's eval status to EVAL
-    // const result = await this.repository.resetToNeedsEvaluation(planId, userId);
-
-    // if (result) {
-    //   console.log(
-    //     'Monitor plan with ID: ' +
-    //       planId +
-    //       ' successfully reset to Needs Evaluation status.',
-    //   );
-    // } else {
-    //   console.log(
-    //     'Failed to reset plan with ID: ' +
-    //       planId +
-    //       ' to Needs Evaluation status.',
-    //   );
-    // }
-    console.log('resetToNeedsEvaluation called');
+    await this.repository.resetToNeedsEvaluation(planId, userId);
   }
 }

--- a/src/monitor-qualification-workspace/monitor-qualification.module.ts
+++ b/src/monitor-qualification-workspace/monitor-qualification.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -10,6 +10,7 @@ import { MonitorQualificationWorkspaceController } from './monitor-qualification
 import { MonitorQualificationWorkspaceService } from './monitor-qualification.service';
 import { MonitorQualificationWorkspaceRepository } from './monitor-qualification.repository';
 import { MonitorQualificationMap } from '../maps/monitor-qualification.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { MonitorQualificationMap } from '../maps/monitor-qualification.map';
     PCTQualificationWorkspaceModule,
     TypeOrmModule.forFeature([MonitorQualificationWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorQualificationWorkspaceController],
   providers: [MonitorQualificationWorkspaceService, MonitorQualificationMap],

--- a/src/monitor-qualification-workspace/monitor-qualification.service.ts
+++ b/src/monitor-qualification-workspace/monitor-qualification.service.ts
@@ -52,7 +52,7 @@ export class MonitorQualificationWorkspaceService {
       qualificationTypeCode: payload.qualificationTypeCode,
       beginDate: payload.beginDate,
       endDate: payload.endDate,
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -74,7 +74,7 @@ export class MonitorQualificationWorkspaceService {
     qual.qualificationTypeCode = payload.qualificationTypeCode;
     qual.beginDate = payload.beginDate;
     qual.endDate = payload.endDate;
-    qual.userId = 'testuser';
+    qual.userId = userId;
     qual.addDate = new Date(Date.now());
     qual.updateDate = new Date(Date.now());
 

--- a/src/monitor-qualification-workspace/monitor-qualification.service.ts
+++ b/src/monitor-qualification-workspace/monitor-qualification.service.ts
@@ -8,6 +8,7 @@ import { MonitorQualificationMap } from '../maps/monitor-qualification.map';
 import { UpdateMonitorQualificationDTO } from '../dtos/monitor-qualification-update.dto';
 import { MonitorQualification } from '../entities/monitor-qualification.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class MonitorQualificationWorkspaceService {
@@ -16,6 +17,7 @@ export class MonitorQualificationWorkspaceService {
     private repository: MonitorQualificationWorkspaceRepository,
     private map: MonitorQualificationMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getQualifications(
@@ -31,7 +33,7 @@ export class MonitorQualificationWorkspaceService {
   ): Promise<MonitorQualification> {
     const result = await this.repository.getQualification(locId, qualId);
     if (!result) {
-      this.Logger.error(NotFoundException, 'Qualification Not Found', true,{
+      this.Logger.error(NotFoundException, 'Qualification Not Found', true, {
         locId: locId,
         qualId: qualId,
       });
@@ -56,6 +58,7 @@ export class MonitorQualificationWorkspaceService {
     });
 
     const result = await this.repository.save(qual);
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(qual);
   }
 
@@ -76,6 +79,7 @@ export class MonitorQualificationWorkspaceService {
     qual.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(qual);
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(result);
   }
 }

--- a/src/monitor-span-workspace/monitor-span.controller.ts
+++ b/src/monitor-span-workspace/monitor-span.controller.ts
@@ -1,4 +1,9 @@
-import { ApiTags, ApiOkResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
 import {
   Get,
   Param,
@@ -13,6 +18,7 @@ import { MonitorSpanDTO } from '../dtos/monitor-span.dto';
 import { MonitorSpanWorkspaceService } from './monitor-span.service';
 import { UpdateMonitorSpanDTO } from '../dtos/monitor-span-update.dto';
 import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { CurrentUser } from '@us-epa-camd/easey-common/decorators';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -41,8 +47,9 @@ export class MonitorSpanWorkspaceController {
     @Param('locId') locationId: string,
     @Param('spanId') spanId: string,
     @Body() payload: UpdateMonitorSpanDTO,
+    @CurrentUser() userId: string,
   ): Promise<MonitorSpanDTO> {
-    return this.service.updateSpan(locationId, spanId, payload);
+    return this.service.updateSpan(locationId, spanId, payload, userId);
   }
 
   @Post()
@@ -56,7 +63,8 @@ export class MonitorSpanWorkspaceController {
   createSpan(
     @Param('locId') locationId: string,
     @Body() payload: UpdateMonitorSpanDTO,
+    @CurrentUser() userId: string,
   ): Promise<MonitorSpanDTO> {
-    return this.service.createSpan(locationId, payload);
+    return this.service.createSpan(locationId, payload, userId);
   }
 }

--- a/src/monitor-span-workspace/monitor-span.module.ts
+++ b/src/monitor-span-workspace/monitor-span.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { MonitorSpanWorkspaceController } from './monitor-span.controller';
 import { MonitorSpanWorkspaceService } from './monitor-span.service';
 import { MonitorSpanWorkspaceRepository } from './monitor-span.repository';
 import { MonitorSpanMap } from '../maps/monitor-span.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MonitorSpanWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorSpanWorkspaceController],
   providers: [MonitorSpanWorkspaceService, MonitorSpanMap],

--- a/src/monitor-span-workspace/monitor-span.service.ts
+++ b/src/monitor-span-workspace/monitor-span.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { v4 as uuid } from 'uuid';
 
 import { UpdateMonitorSpanDTO } from '../dtos/monitor-span-update.dto';
@@ -15,6 +16,7 @@ export class MonitorSpanWorkspaceService {
     private repository: MonitorSpanWorkspaceRepository,
     private map: MonitorSpanMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getSpans(locationId: string): Promise<MonitorSpanDTO[]> {
@@ -26,7 +28,7 @@ export class MonitorSpanWorkspaceService {
     const result = await this.repository.getSpan(locationId, spanId);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'Monitor Span not found', true,{
+      this.Logger.error(NotFoundException, 'Monitor Span not found', true, {
         locationId: locationId,
         spanId: spanId,
       });
@@ -66,7 +68,7 @@ export class MonitorSpanWorkspaceService {
     });
 
     const result = await this.repository.save(span);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.map.one(result);
   }
 
@@ -99,7 +101,7 @@ export class MonitorSpanWorkspaceService {
     span.updateDate = new Date(Date.now());
 
     await this.repository.save(span);
-
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.getSpan(locationId, spanId);
   }
 }

--- a/src/monitor-span-workspace/monitor-span.service.ts
+++ b/src/monitor-span-workspace/monitor-span.service.ts
@@ -40,6 +40,7 @@ export class MonitorSpanWorkspaceService {
   async createSpan(
     locationId: string,
     payload: UpdateMonitorSpanDTO,
+    userId: string,
   ): Promise<MonitorSpanDTO> {
     const span = this.repository.create({
       id: uuid(),
@@ -61,14 +62,13 @@ export class MonitorSpanWorkspaceService {
       beginHour: payload.beginHour,
       endDate: payload.endDate,
       endHour: payload.endHour,
-      // TODO
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     const result = await this.repository.save(span);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(result);
   }
 
@@ -76,6 +76,7 @@ export class MonitorSpanWorkspaceService {
     locationId: string,
     spanId: string,
     payload: UpdateMonitorSpanDTO,
+    userId: string,
   ): Promise<MonitorSpanDTO> {
     const span = await this.getSpan(locationId, spanId);
 
@@ -96,12 +97,11 @@ export class MonitorSpanWorkspaceService {
     span.beginHour = payload.beginHour;
     span.endDate = payload.endDate;
     span.endHour = payload.endHour;
-    // TODO
-    span.userid = 'testuser';
+    span.userid = userId;
     span.updateDate = new Date(Date.now());
 
     await this.repository.save(span);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getSpan(locationId, spanId);
   }
 }

--- a/src/monitor-system-workspace/monitor-system.controller.ts
+++ b/src/monitor-system-workspace/monitor-system.controller.ts
@@ -1,4 +1,9 @@
-import { ApiTags, ApiOkResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
 import {
   Get,
   Param,
@@ -13,6 +18,7 @@ import { MonitorSystemWorkspaceService } from './monitor-system.service';
 import { MonitorSystemDTO } from '../dtos/monitor-system.dto';
 import { UpdateMonitorSystemDTO } from '../dtos/monitor-system-update.dto';
 import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { CurrentUser } from '@us-epa-camd/easey-common/decorators';
 
 @Controller()
 @ApiTags('Systems')
@@ -41,8 +47,9 @@ export class MonitorSystemWorkspaceController {
   createSystem(
     @Param('locId') locationId: string,
     @Body() payload: UpdateMonitorSystemDTO,
+    @CurrentUser() userId: string,
   ): Promise<MonitorSystemDTO> {
-    return this.service.createSystem(locationId, payload);
+    return this.service.createSystem(locationId, payload, userId);
   }
 
   @Put(':sysId')
@@ -57,7 +64,13 @@ export class MonitorSystemWorkspaceController {
     @Param('locId') locationId: string,
     @Param('sysId') monitoringSystemId: string,
     @Body() payload: UpdateMonitorSystemDTO,
+    @CurrentUser() userId: string,
   ): Promise<MonitorSystemDTO> {
-    return this.service.updateSystem(monitoringSystemId, payload);
+    return this.service.updateSystem(
+      monitoringSystemId,
+      payload,
+      locationId,
+      userId,
+    );
   }
 }

--- a/src/monitor-system-workspace/monitor-system.module.ts
+++ b/src/monitor-system-workspace/monitor-system.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -9,6 +9,7 @@ import { MonitorSystemWorkspaceController } from './monitor-system.controller';
 import { MonitorSystemWorkspaceService } from './monitor-system.service';
 import { MonitorSystemWorkspaceRepository } from './monitor-system.repository';
 import { MonitorSystemMap } from '../maps/monitor-system.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { MonitorSystemMap } from '../maps/monitor-system.map';
     SystemComponentWorkspaceModule,
     TypeOrmModule.forFeature([MonitorSystemWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [MonitorSystemWorkspaceController],
   providers: [MonitorSystemWorkspaceService, MonitorSystemMap],

--- a/src/monitor-system-workspace/monitor-system.service.ts
+++ b/src/monitor-system-workspace/monitor-system.service.ts
@@ -8,6 +8,7 @@ import { MonitorSystemMap } from '../maps/monitor-system.map';
 import { MonitorSystemWorkspaceRepository } from './monitor-system.repository';
 import { MonitorSystem } from '../entities/monitor-system.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class MonitorSystemWorkspaceService {
@@ -16,6 +17,7 @@ export class MonitorSystemWorkspaceService {
     private repository: MonitorSystemWorkspaceRepository,
     private map: MonitorSystemMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getSystems(locationId: string): Promise<MonitorSystemDTO[]> {
@@ -51,6 +53,7 @@ export class MonitorSystemWorkspaceService {
     });
 
     const result = await this.repository.save(system);
+    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
     return this.map.one(system);
   }
 
@@ -58,7 +61,7 @@ export class MonitorSystemWorkspaceService {
     const result = await this.repository.findOne(monitoringSystemId);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'Monitor System Not Found', true,{
+      this.Logger.error(NotFoundException, 'Monitor System Not Found', true, {
         monitoringSystemId: monitoringSystemId,
       });
     }
@@ -84,6 +87,7 @@ export class MonitorSystemWorkspaceService {
     system.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(system);
+    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
     return this.map.one(result);
   }
 }

--- a/src/monitor-system-workspace/monitor-system.service.ts
+++ b/src/monitor-system-workspace/monitor-system.service.ts
@@ -35,6 +35,7 @@ export class MonitorSystemWorkspaceService {
   async createSystem(
     locationId: string,
     payload: UpdateMonitorSystemDTO,
+    userId: string,
   ): Promise<MonitorSystemDTO> {
     const system = this.repository.create({
       id: uuid(),
@@ -47,13 +48,13 @@ export class MonitorSystemWorkspaceService {
       beginHour: payload.beginHour,
       endDate: payload.endDate,
       endHour: payload.endHour,
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     const result = await this.repository.save(system);
-    await this.mpService.resetToNeedsEvaluation(locationId, 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(system);
   }
 
@@ -72,6 +73,8 @@ export class MonitorSystemWorkspaceService {
   async updateSystem(
     monitoringSystemId: string,
     payload: UpdateMonitorSystemDTO,
+    locId: string,
+    userId: string,
   ): Promise<MonitorSystemDTO> {
     const system = await this.getSystem(monitoringSystemId);
 
@@ -82,12 +85,11 @@ export class MonitorSystemWorkspaceService {
     system.beginHour = payload.beginHour;
     system.endDate = payload.endDate;
     system.endHour = payload.endHour;
-    // TODO: update to actual user logged in
-    system.userId = 'testuser';
+    system.userId = userId;
     system.updateDate = new Date(Date.now());
 
     const result = await this.repository.save(system);
-    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(result);
   }
 }

--- a/src/pct-qualification-workspace/pct-qualification.module.ts
+++ b/src/pct-qualification-workspace/pct-qualification.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { PCTQualificationWorkspaceController } from './pct-qualification.control
 import { PCTQualificationWorkspaceService } from './pct-qualification.service';
 import { PCTQualificationWorkspaceRepository } from './pct-qualification.repository';
 import { PCTQualificationMap } from '../maps/pct-qualification.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([PCTQualificationWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [PCTQualificationWorkspaceController],
   providers: [PCTQualificationWorkspaceService, PCTQualificationMap],

--- a/src/pct-qualification-workspace/pct-qualification.service.ts
+++ b/src/pct-qualification-workspace/pct-qualification.service.ts
@@ -7,6 +7,7 @@ import { PCTQualificationMap } from '../maps/pct-qualification.map';
 import { UpdatePCTQualificationDTO } from '../dtos/pct-qualification-update.dto';
 
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class PCTQualificationWorkspaceService {
@@ -15,6 +16,7 @@ export class PCTQualificationWorkspaceService {
     private repository: PCTQualificationWorkspaceRepository,
     private map: PCTQualificationMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getPCTQualifications(
@@ -36,11 +38,16 @@ export class PCTQualificationWorkspaceService {
       pctQualId,
     );
     if (!result) {
-      this.Logger.error(NotFoundException, 'PCT Qualification Not Found', true,{
-        locId: locId,
-        qualId: qualId,
-        pctQualId: pctQualId,
-      });
+      this.Logger.error(
+        NotFoundException,
+        'PCT Qualification Not Found',
+        true,
+        {
+          locId: locId,
+          qualId: qualId,
+          pctQualId: pctQualId,
+        },
+      );
     }
     return this.map.one(result);
   }
@@ -71,7 +78,7 @@ export class PCTQualificationWorkspaceService {
     });
 
     const result = await this.repository.save(load);
-
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(result);
   }
 
@@ -100,6 +107,7 @@ export class PCTQualificationWorkspaceService {
     pctQual.updateDate = new Date(Date.now());
 
     await this.repository.save(pctQual);
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.getPCTQualification(locId, qualId, pctQualId);
   }
 }

--- a/src/pct-qualification-workspace/pct-qualification.service.ts
+++ b/src/pct-qualification-workspace/pct-qualification.service.ts
@@ -72,7 +72,7 @@ export class PCTQualificationWorkspaceService {
       yr3QualificationDataYear: payload.yr3QualificationDataYear,
       yr3QualificationDataTypeCode: payload.yr3QualificationDataTypeCode,
       yr3PercentageValue: payload.yr3PercentageValue,
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -103,7 +103,7 @@ export class PCTQualificationWorkspaceService {
     pctQual.yr3QualificationDataYear = payload.yr3QualificationDataYear;
     pctQual.yr3QualificationDataTypeCode = payload.yr3QualificationDataTypeCode;
     pctQual.yr3PercentageValue = payload.yr3PercentageValue;
-    pctQual.userId = 'testuser';
+    pctQual.userId = userId;
     pctQual.updateDate = new Date(Date.now());
 
     await this.repository.save(pctQual);

--- a/src/system-component-workspace/system-component.controller.ts
+++ b/src/system-component-workspace/system-component.controller.ts
@@ -1,4 +1,9 @@
-import { ApiTags, ApiOkResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
 import {
   Get,
   Param,
@@ -13,6 +18,7 @@ import { SystemComponentWorkspaceService } from './system-component.service';
 import { SystemComponentDTO } from '../dtos/system-component.dto';
 import { UpdateSystemComponentDTO } from '../dtos/system-component-update.dto';
 import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { CurrentUser } from '@us-epa-camd/easey-common/decorators';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -44,6 +50,7 @@ export class SystemComponentWorkspaceController {
     @Param('locId') locationId: string,
     @Param('sysId') monSysId: string,
     @Param('compId') componentId: string,
+    @CurrentUser() userId: string,
     @Body() payload: UpdateSystemComponentDTO,
   ): Promise<SystemComponentDTO> {
     return this.service.updateComponent(
@@ -51,6 +58,7 @@ export class SystemComponentWorkspaceController {
       monSysId,
       componentId,
       payload,
+      userId,
     );
   }
 
@@ -64,8 +72,14 @@ export class SystemComponentWorkspaceController {
   createSystemComponent(
     @Param('locId') locationId: string,
     @Param('sysId') monSysId: string,
+    @CurrentUser() userId: string,
     @Body() payload: UpdateSystemComponentDTO,
   ): Promise<SystemComponentDTO> {
-    return this.service.createSystemComponent(locationId, monSysId, payload);
+    return this.service.createSystemComponent(
+      locationId,
+      monSysId,
+      payload,
+      userId,
+    );
   }
 }

--- a/src/system-component-workspace/system-component.module.ts
+++ b/src/system-component-workspace/system-component.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -7,12 +7,14 @@ import { SystemComponentWorkspaceService } from './system-component.service';
 import { SystemComponentWorkspaceRepository } from './system-component.repository';
 import { SystemComponentMap } from '../maps/system-component.map';
 import { ComponentWorkspaceModule } from '../component-workspace/component.module';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     ComponentWorkspaceModule,
     TypeOrmModule.forFeature([SystemComponentWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [SystemComponentWorkspaceController],
   providers: [SystemComponentWorkspaceService, SystemComponentMap],

--- a/src/system-component-workspace/system-component.service.ts
+++ b/src/system-component-workspace/system-component.service.ts
@@ -57,6 +57,7 @@ export class SystemComponentWorkspaceService {
     sysId: string,
     componentId: string,
     payload: UpdateSystemComponentDTO,
+    userId: string,
   ): Promise<SystemComponentDTO> {
     const systemComponent = await this.getComponent(sysId, componentId);
 
@@ -65,11 +66,11 @@ export class SystemComponentWorkspaceService {
     systemComponent.endDate = payload.endDate;
     systemComponent.endHour = payload.endHour;
     // TODO: userId
-    systemComponent.userId = 'testuser';
+    systemComponent.userId = userId;
     systemComponent.updateDate = new Date(Date.now());
 
     await this.repository.save(systemComponent);
-    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getComponent(sysId, componentId);
   }
 
@@ -77,6 +78,7 @@ export class SystemComponentWorkspaceService {
     locationId: string,
     monitoringSystemRecordId: string,
     payload: UpdateSystemComponentDTO,
+    userId: string,
   ): Promise<SystemComponentDTO> {
     let component = await this.componentService.getComponentByIdentifier(
       locationId,
@@ -111,14 +113,13 @@ export class SystemComponentWorkspaceService {
       beginHour: payload.beginHour,
       endDate: payload.endDate,
       endHour: payload.endHour,
-      // TODO
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     await this.repository.save(systemComponent);
-    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.getComponent(monitoringSystemRecordId, component.id);
   }
 }

--- a/src/system-component-workspace/system-component.service.ts
+++ b/src/system-component-workspace/system-component.service.ts
@@ -10,6 +10,7 @@ import { SystemComponentWorkspaceRepository } from './system-component.repositor
 import { SystemComponent } from '../entities/system-component.entity';
 import { ComponentWorkspaceService } from '../component-workspace/component.service';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class SystemComponentWorkspaceService {
@@ -19,6 +20,7 @@ export class SystemComponentWorkspaceService {
     private componentService: ComponentWorkspaceService,
     private map: SystemComponentMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getComponents(
@@ -36,10 +38,15 @@ export class SystemComponentWorkspaceService {
     const result = await this.repository.getComponent(sysId, componentId);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'System component was not found', true,{
-        sysId: sysId,
-        componentId: componentId,
-      });
+      this.Logger.error(
+        NotFoundException,
+        'System component was not found',
+        true,
+        {
+          sysId: sysId,
+          componentId: componentId,
+        },
+      );
     }
 
     return this.map.one(result);
@@ -62,7 +69,7 @@ export class SystemComponentWorkspaceService {
     systemComponent.updateDate = new Date(Date.now());
 
     await this.repository.save(systemComponent);
-
+    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
     return this.getComponent(sysId, componentId);
   }
 
@@ -111,7 +118,7 @@ export class SystemComponentWorkspaceService {
     });
 
     await this.repository.save(systemComponent);
-
+    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
     return this.getComponent(monitoringSystemRecordId, component.id);
   }
 }

--- a/src/system-fuel-flow-workspace/system-fuel-flow.controller.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.controller.ts
@@ -1,4 +1,9 @@
-import { ApiTags, ApiOkResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiBearerAuth,
+  ApiSecurity,
+} from '@nestjs/swagger';
 import {
   Get,
   Param,
@@ -57,7 +62,12 @@ export class SystemFuelFlowWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.createFuelFlow(monitoringSystemRecordId, payload);
+    return this.service.createFuelFlow(
+      monitoringSystemRecordId,
+      payload,
+      locationId,
+      userId,
+    );
   }
 
   @Put(':fuelFlowId')
@@ -82,6 +92,6 @@ export class SystemFuelFlowWorkspaceController {
       payload: payload,
       userId: userId,
     });
-    return this.service.updateFuelFlow(id, payload);
+    return this.service.updateFuelFlow(id, payload, locationId, userId);
   }
 }

--- a/src/system-fuel-flow-workspace/system-fuel-flow.module.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { SystemFuelFlowWorkspaceController } from './system-fuel-flow.controller
 import { SystemFuelFlowWorkspaceService } from './system-fuel-flow.service';
 import { SystemFuelFlowWorkspaceRepository } from './system-fuel-flow.repository';
 import { SystemFuelFlowMap } from '../maps/system-fuel-flow.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([SystemFuelFlowWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [SystemFuelFlowWorkspaceController],
   providers: [SystemFuelFlowWorkspaceService, SystemFuelFlowMap],

--- a/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
@@ -39,6 +39,8 @@ export class SystemFuelFlowWorkspaceService {
   async createFuelFlow(
     monitoringSystemRecordId: string,
     payload: UpdateSystemFuelFlowDTO,
+    locId: string,
+    userId: string,
   ): Promise<SystemFuelFlowDTO> {
     const fuelFlow = this.repository.create({
       id: uuid(),
@@ -50,21 +52,21 @@ export class SystemFuelFlowWorkspaceService {
       beginHour: payload.beginHour,
       endDate: payload.endDate,
       endHour: payload.endHour,
-
-      // TODO: userId to be determined
-      userId: 'testuser',
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
 
     await this.repository.save(fuelFlow);
-    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.getFuelFlow(fuelFlow.id);
   }
 
   async updateFuelFlow(
     fuelFlowId: string,
     payload: UpdateSystemFuelFlowDTO,
+    locId: string,
+    userId: string,
   ): Promise<SystemFuelFlowDTO> {
     const fuelFlow = await this.getFuelFlow(fuelFlowId);
 
@@ -78,7 +80,7 @@ export class SystemFuelFlowWorkspaceService {
     fuelFlow.endHour = payload.endHour;
 
     await this.repository.save(fuelFlow);
-    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.getFuelFlow(fuelFlowId);
   }
 }

--- a/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
@@ -7,6 +7,7 @@ import { SystemFuelFlowWorkspaceRepository } from './system-fuel-flow.repository
 import { SystemFuelFlowMap } from '../maps/system-fuel-flow.map';
 import { UpdateSystemFuelFlowDTO } from '../dtos/system-fuel-flow-update.dto';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class SystemFuelFlowWorkspaceService {
@@ -15,6 +16,7 @@ export class SystemFuelFlowWorkspaceService {
     private readonly repository: SystemFuelFlowWorkspaceRepository,
     private readonly map: SystemFuelFlowMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getFuelFlows(monSysId: string): Promise<SystemFuelFlowDTO[]> {
@@ -26,7 +28,7 @@ export class SystemFuelFlowWorkspaceService {
     const result = await this.repository.getFuelFlow(fuelFlowId);
 
     if (!result) {
-      this.Logger.error(NotFoundException, 'Fuel Flow not found.', true,{
+      this.Logger.error(NotFoundException, 'Fuel Flow not found.', true, {
         fuelFlowId: fuelFlowId,
       });
     }
@@ -56,7 +58,7 @@ export class SystemFuelFlowWorkspaceService {
     });
 
     await this.repository.save(fuelFlow);
-
+    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
     return this.getFuelFlow(fuelFlow.id);
   }
 
@@ -76,7 +78,7 @@ export class SystemFuelFlowWorkspaceService {
     fuelFlow.endHour = payload.endHour;
 
     await this.repository.save(fuelFlow);
-
+    await this.mpService.resetToNeedsEvaluation('locId', 'userId');
     return this.getFuelFlow(fuelFlowId);
   }
 }

--- a/src/unit-capacity-workspace/unit-capacity.module.ts
+++ b/src/unit-capacity-workspace/unit-capacity.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { UnitCapacityWorkspaceController } from './unit-capacity.controller';
 import { UnitCapacityWorkspaceService } from './unit-capacity.service';
 import { UnitCapacityWorkspaceRepository } from './unit-capacity.repository';
 import { UnitCapacityMap } from '../maps/unit-capacity.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([UnitCapacityWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [UnitCapacityWorkspaceController],
   providers: [UnitCapacityWorkspaceService, UnitCapacityMap],

--- a/src/unit-capacity-workspace/unit-capacity.service.ts
+++ b/src/unit-capacity-workspace/unit-capacity.service.ts
@@ -59,7 +59,7 @@ export class UnitCapacityWorkspaceService {
       maximumHourlyHeatInputCapacity: payload.maximumHourlyHeatInputCapacity,
       beginDate: payload.beginDate,
       endDate: payload.endDate,
-      userId: userId.slice(0, 8),
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -86,7 +86,7 @@ export class UnitCapacityWorkspaceService {
       payload.maximumHourlyHeatInputCapacity;
     unitCapacity.beginDate = payload.beginDate;
     unitCapacity.endDate = payload.endDate;
-    unitCapacity.userId = userId.slice(0, 8);
+    unitCapacity.userId = userId;
     unitCapacity.updateDate = new Date(Date.now());
 
     await this.repository.save(unitCapacity);

--- a/src/unit-capacity-workspace/unit-capacity.service.ts
+++ b/src/unit-capacity-workspace/unit-capacity.service.ts
@@ -6,6 +6,7 @@ import { UnitCapacityMap } from '../maps/unit-capacity.map';
 import { UnitCapacityDTO } from '../dtos/unit-capacity.dto';
 import { UnitCapacityWorkspaceRepository } from './unit-capacity.repository';
 import { UpdateUnitCapacityDTO } from '../dtos/unit-capacity-update.dto';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class UnitCapacityWorkspaceService {
@@ -13,6 +14,7 @@ export class UnitCapacityWorkspaceService {
     private readonly logger: Logger,
     private readonly repository: UnitCapacityWorkspaceRepository,
     private readonly map: UnitCapacityMap,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getUnitCapacities(
@@ -37,7 +39,7 @@ export class UnitCapacityWorkspaceService {
       unitCapacityId,
     );
     if (!result) {
-      this.logger.error(NotFoundException, 'Monitor Load Not Found', true,{
+      this.logger.error(NotFoundException, 'Monitor Load Not Found', true, {
         unitId,
         unitCapacityId,
       });
@@ -63,7 +65,7 @@ export class UnitCapacityWorkspaceService {
     });
 
     const result = await this.repository.save(unitCapacity);
-
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.getUnitCapacity(locId, unitId, result.id);
   }
 
@@ -88,6 +90,7 @@ export class UnitCapacityWorkspaceService {
     unitCapacity.updateDate = new Date(Date.now());
 
     await this.repository.save(unitCapacity);
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.getUnitCapacity(locId, unitRecordId, unitCapacityId);
   }
 }

--- a/src/unit-control-workspace/unit-control.module.ts
+++ b/src/unit-control-workspace/unit-control.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { UnitControlWorkspaceController } from './unit-control.controller';
 import { UnitControlWorkspaceService } from './unit-control.service';
 import { UnitControlWorkspaceRepository } from './unit-control.repository';
 import { UnitControlMap } from '../maps/unit-control.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([UnitControlWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [UnitControlWorkspaceController],
   providers: [UnitControlWorkspaceService, UnitControlMap],

--- a/src/unit-control-workspace/unit-control.service.ts
+++ b/src/unit-control-workspace/unit-control.service.ts
@@ -62,7 +62,7 @@ export class UnitControlWorkspaceService {
       originalCode: payload.originalCode,
       retireDate: payload.retireDate,
       seasonalControlsIndicator: payload.seasonalControlsIndicator,
-      userId: userId.slice(0, 8),
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -88,7 +88,7 @@ export class UnitControlWorkspaceService {
     unitControl.originalCode = payload.originalCode;
     unitControl.retireDate = payload.retireDate;
     unitControl.seasonalControlsIndicator = payload.seasonalControlsIndicator;
-    unitControl.userId = userId.slice(0, 8);
+    unitControl.userId = userId;
     unitControl.updateDate = new Date(Date.now());
 
     await this.repository.save(unitControl);

--- a/src/unit-control-workspace/unit-control.service.ts
+++ b/src/unit-control-workspace/unit-control.service.ts
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid';
 
 import { UnitControlWorkspaceRepository } from './unit-control.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 
 @Injectable()
 export class UnitControlWorkspaceService {
@@ -15,6 +16,7 @@ export class UnitControlWorkspaceService {
     readonly repository: UnitControlWorkspaceRepository,
     readonly map: UnitControlMap,
     private Logger: Logger,
+    private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
   async getUnitControls(
@@ -36,7 +38,7 @@ export class UnitControlWorkspaceService {
       unitControlId,
     );
     if (!result) {
-      this.Logger.error(NotFoundException, 'Monitor Load Not Found', true,{
+      this.Logger.error(NotFoundException, 'Monitor Load Not Found', true, {
         unitId: unitId,
         unitControlId: unitControlId,
       });
@@ -66,6 +68,7 @@ export class UnitControlWorkspaceService {
     });
 
     const result = await this.repository.save(load);
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(result);
   }
 
@@ -89,6 +92,7 @@ export class UnitControlWorkspaceService {
     unitControl.updateDate = new Date(Date.now());
 
     await this.repository.save(unitControl);
+    await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.getUnitControl(locId, unitId, unitControlId);
   }
 }

--- a/src/unit-fuel-workspace/unit-fuel.module.ts
+++ b/src/unit-fuel-workspace/unit-fuel.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 
@@ -6,11 +6,13 @@ import { UnitFuelWorkspaceController } from './unit-fuel.controller';
 import { UnitFuelWorkspaceService } from './unit-fuel.service';
 import { UnitFuelWorkspaceRepository } from './unit-fuel.repository';
 import { UnitFuelMap } from '../maps/unit-fuel.map';
+import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([UnitFuelWorkspaceRepository]),
     HttpModule,
+    forwardRef(() => MonitorPlanWorkspaceModule),
   ],
   controllers: [UnitFuelWorkspaceController],
   providers: [UnitFuelWorkspaceService, UnitFuelMap],

--- a/src/unit-fuel-workspace/unit-fuel.service.ts
+++ b/src/unit-fuel-workspace/unit-fuel.service.ts
@@ -46,8 +46,6 @@ export class UnitFuelWorkspaceService {
     unitId: number,
     payload: UpdateUnitFuelDTO,
   ): Promise<UnitFuelDTO> {
-    // temporary:
-    const testUserId = 'testuser';
     const unitFuel = this.repository.create({
       id: uuid(),
       unitId: unitId,
@@ -58,7 +56,7 @@ export class UnitFuelWorkspaceService {
       demSO2: payload.demSO2,
       beginDate: payload.beginDate,
       endDate: payload.endDate,
-      userId: testUserId,
+      userId: userId,
       addDate: new Date(Date.now()),
       updateDate: new Date(Date.now()),
     });
@@ -84,9 +82,7 @@ export class UnitFuelWorkspaceService {
     unitFuel.demSO2 = payload.demSO2;
     unitFuel.beginDate = payload.beginDate;
     unitFuel.endDate = payload.endDate;
-    // unitFuel.userId = userId;
-    // temporary:
-    unitFuel.userId = 'testuser';
+    unitFuel.userId = userId;
     unitFuel.updateDate = new Date(Date.now());
 
     await this.repository.save(unitFuel);


### PR DESCRIPTION
- added new mon plan service to handle resetting eval status code (and updating related fields)
- removed remaining slicing of the current userid when update/creating records
- added missing userid & locationId parameters to services
- hooked up all POST & PUT's to trigger the reset eval status service after a successful update
