### PR TITLE
moved end date and end hour validation from entity to DTO files

### DIFF
--- a/src/analyzer-range-workspace/analyzer-range.controller.ts
+++ b/src/analyzer-range-workspace/analyzer-range.controller.ts
@@ -89,7 +89,7 @@ export class AnalyzerRangeWorkspaceController {
       analyzerRangeId: analyzerRangeId,
       payload: payload,
     });
-    return this.service.updateAnalyzerRangd(
+    return this.service.updateAnalyzerRange(
       analyzerRangeId,
       payload,
       locationId,

--- a/src/analyzer-range-workspace/analyzer-range.service.ts
+++ b/src/analyzer-range-workspace/analyzer-range.service.ts
@@ -11,7 +11,6 @@ import { AnalyzerRange } from '../entities/analyzer-range.entity';
 import { AnalyzerRangeWorkspaceRepository } from './analyzer-range.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class AnalyzerRangeWorkspaceService {
@@ -60,13 +59,12 @@ export class AnalyzerRangeWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(analyzerRange);
     await this.repository.save(analyzerRange);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(analyzerRange);
   }
 
-  async updateAnalyzerRangd(
+  async updateAnalyzerRange(
     analyzerRangeId: string,
     payload: UpdateAnalyzerRangeDTO,
     locationId: string,
@@ -81,7 +79,6 @@ export class AnalyzerRangeWorkspaceService {
     analyzerRange.endDate = payload.endDate;
     analyzerRange.endHour = payload.endHour;
 
-    await validateObject(analyzerRange);
     await this.repository.save(analyzerRange);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(analyzerRange);

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -29,6 +29,6 @@ export default registerAs('app', () => ({
   published: process.env.EASEY_MONITOR_PLAN_API_PUBLISHED || 'local',
   // AUTH API MUST BE RUN LOCALLY FOR LOCAL DEVELOPMENT
   authApi: {
-    uri: process.env.EASEY_AUTH_API || 'https://localhost:8000/auth-mgmt',
+    uri: process.env.EASEY_AUTH_API || 'http://localhost:8000/auth-mgmt',
   },
 }));

--- a/src/dtos/analyzer-range-base.dto.ts
+++ b/src/dtos/analyzer-range-base.dto.ts
@@ -1,46 +1,52 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 export class AnalyzerRangeBaseDTO {
   @ApiProperty({
     description: propertyMetadata.analyzerRangeDTOAnalyzerRangeCode.description,
     example: propertyMetadata.analyzerRangeDTOAnalyzerRangeCode.example,
-    name: propertyMetadata.analyzerRangeDTOAnalyzerRangeCode.fieldLabels.value
+    name: propertyMetadata.analyzerRangeDTOAnalyzerRangeCode.fieldLabels.value,
   })
   analyzerRangeCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.analyzerRangeDTODualRangeIndicator.description,
+    description:
+      propertyMetadata.analyzerRangeDTODualRangeIndicator.description,
     example: propertyMetadata.analyzerRangeDTODualRangeIndicator.example,
-    name: propertyMetadata.analyzerRangeDTODualRangeIndicator.fieldLabels.value
+    name: propertyMetadata.analyzerRangeDTODualRangeIndicator.fieldLabels.value,
   })
   dualRangeIndicator: number;
 
   @ApiProperty({
     description: propertyMetadata.analyzerRangeDTOBeginDate.description,
     example: propertyMetadata.analyzerRangeDTOBeginDate.example,
-    name: propertyMetadata.analyzerRangeDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.analyzerRangeDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.analyzerRangeDTOBeginHour.description,
     example: propertyMetadata.analyzerRangeDTOBeginHour.example,
-    name: propertyMetadata.analyzerRangeDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.analyzerRangeDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.analyzerRangeDTOEndDate.description,
     example: propertyMetadata.analyzerRangeDTOEndDate.example,
-    name: propertyMetadata.analyzerRangeDTOEndDate.fieldLabels.value
+    name: propertyMetadata.analyzerRangeDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.analyzerRangeDTOEndHour.description,
     example: propertyMetadata.analyzerRangeDTOEndHour.example,
-    name: propertyMetadata.analyzerRangeDTOEndHour.fieldLabels.value
+    name: propertyMetadata.analyzerRangeDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/duct-waf-base.dto.ts
+++ b/src/dtos/duct-waf-base.dto.ts
@@ -1,96 +1,105 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 export class DuctWafBaseDTO {
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafDeterminationDate.description,
     example: propertyMetadata.ductWafDTOWafDeterminationDate.example,
-    name: propertyMetadata.ductWafDTOWafDeterminationDate.fieldLabels.value
+    name: propertyMetadata.ductWafDTOWafDeterminationDate.fieldLabels.value,
   })
   wafDeterminationDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafBeginDate.description,
     example: propertyMetadata.ductWafDTOWafBeginDate.example,
-    name: propertyMetadata.ductWafDTOWafBeginDate.fieldLabels.value
+    name: propertyMetadata.ductWafDTOWafBeginDate.fieldLabels.value,
   })
   wafBeginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafBeginHour.description,
     example: propertyMetadata.ductWafDTOWafBeginHour.example,
-    name: propertyMetadata.ductWafDTOWafBeginHour.fieldLabels.value
+    name: propertyMetadata.ductWafDTOWafBeginHour.fieldLabels.value,
   })
   wafBeginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafMethodCode.description,
     example: propertyMetadata.ductWafDTOWafMethodCode.example,
-    name: propertyMetadata.ductWafDTOWafMethodCode.fieldLabels.value
+    name: propertyMetadata.ductWafDTOWafMethodCode.fieldLabels.value,
   })
   wafMethodCode: string;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafValue.description,
     example: propertyMetadata.ductWafDTOWafValue.example,
-    name: propertyMetadata.ductWafDTOWafValue.fieldLabels.value
+    name: propertyMetadata.ductWafDTOWafValue.fieldLabels.value,
   })
   wafValue: number;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTONumberOfTestRuns.description,
     example: propertyMetadata.ductWafDTONumberOfTestRuns.example,
-    name: propertyMetadata.ductWafDTONumberOfTestRuns.fieldLabels.value
+    name: propertyMetadata.ductWafDTONumberOfTestRuns.fieldLabels.value,
   })
   numberOfTestRuns: number;
 
   @ApiProperty({
-    description: propertyMetadata.ductWafDTONumberOfTraversePointsWaf.description,
+    description:
+      propertyMetadata.ductWafDTONumberOfTraversePointsWaf.description,
     example: propertyMetadata.ductWafDTONumberOfTraversePointsWaf.example,
-    name: propertyMetadata.ductWafDTONumberOfTraversePointsWaf.fieldLabels.value
+    name:
+      propertyMetadata.ductWafDTONumberOfTraversePointsWaf.fieldLabels.value,
   })
   numberOfTraversePointsWaf: number;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTONumberOfTestPorts.description,
     example: propertyMetadata.ductWafDTONumberOfTestPorts.example,
-    name: propertyMetadata.ductWafDTONumberOfTestPorts.fieldLabels.value
+    name: propertyMetadata.ductWafDTONumberOfTestPorts.fieldLabels.value,
   })
   numberOfTestPorts: number;
 
   @ApiProperty({
-    description: propertyMetadata.ductWafDTONumberOfTraversePointsRef.description,
+    description:
+      propertyMetadata.ductWafDTONumberOfTraversePointsRef.description,
     example: propertyMetadata.ductWafDTONumberOfTraversePointsRef.example,
-    name: propertyMetadata.ductWafDTONumberOfTraversePointsRef.fieldLabels.value
+    name:
+      propertyMetadata.ductWafDTONumberOfTraversePointsRef.fieldLabels.value,
   })
   numberOfTraversePointsRef: number;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTODuctWidth.description,
     example: propertyMetadata.ductWafDTODuctWidth.example,
-    name: propertyMetadata.ductWafDTODuctWidth.fieldLabels.value
+    name: propertyMetadata.ductWafDTODuctWidth.fieldLabels.value,
   })
   ductWidth: number;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTODuctDepth.description,
     example: propertyMetadata.ductWafDTODuctDepth.example,
-    name: propertyMetadata.ductWafDTODuctDepth.fieldLabels.value
+    name: propertyMetadata.ductWafDTODuctDepth.fieldLabels.value,
   })
   ductDepth: number;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafEndDate.description,
     example: propertyMetadata.ductWafDTOWafEndDate.example,
-    name: propertyMetadata.ductWafDTOWafEndDate.fieldLabels.value
+    name: propertyMetadata.ductWafDTOWafEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.wafEndHour !== null)
   wafEndDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafEndHour.description,
     example: propertyMetadata.ductWafDTOWafEndHour.example,
-    name: propertyMetadata.ductWafDTOWafEndHour.fieldLabels.value
+    name: propertyMetadata.ductWafDTOWafEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.wafEndDate !== null)
   wafEndHour: number;
 
   active: boolean;

--- a/src/dtos/mats-method-base.dto.ts
+++ b/src/dtos/mats-method-base.dto.ts
@@ -1,7 +1,6 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { IsNotEmpty, ValidateIf, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
-import { IsOptional } from 'class-validator';
 
 export class MatsMethodBaseDTO {
   @ApiProperty({

--- a/src/dtos/mats-method-base.dto.ts
+++ b/src/dtos/mats-method-base.dto.ts
@@ -1,49 +1,64 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 import { IsOptional } from 'class-validator';
 
 export class MatsMethodBaseDTO {
   @ApiProperty({
-    description: propertyMetadata.matsMethodDTOSupplementalMATSParameterCode.description,
-    example: propertyMetadata.matsMethodDTOSupplementalMATSParameterCode.example,
-    name: propertyMetadata.matsMethodDTOSupplementalMATSParameterCode.fieldLabels.value
+    description:
+      propertyMetadata.matsMethodDTOSupplementalMATSParameterCode.description,
+    example:
+      propertyMetadata.matsMethodDTOSupplementalMATSParameterCode.example,
+    name:
+      propertyMetadata.matsMethodDTOSupplementalMATSParameterCode.fieldLabels
+        .value,
   })
   supplementalMATSParameterCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.matsMethodDTOSupplementalMATSMonitoringMethodCode.description,
-    example: propertyMetadata.matsMethodDTOSupplementalMATSMonitoringMethodCode.example,
-    name: propertyMetadata.matsMethodDTOSupplementalMATSMonitoringMethodCode.fieldLabels.value
+    description:
+      propertyMetadata.matsMethodDTOSupplementalMATSMonitoringMethodCode
+        .description,
+    example:
+      propertyMetadata.matsMethodDTOSupplementalMATSMonitoringMethodCode
+        .example,
+    name:
+      propertyMetadata.matsMethodDTOSupplementalMATSMonitoringMethodCode
+        .fieldLabels.value,
   })
   supplementalMATSMonitoringMethodCode: string;
 
   @ApiProperty({
     description: propertyMetadata.matsMethodDTOBeginDate.description,
     example: propertyMetadata.matsMethodDTOBeginDate.example,
-    name: propertyMetadata.matsMethodDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.matsMethodDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.matsMethodDTOBeginHour.description,
     example: propertyMetadata.matsMethodDTOBeginHour.example,
-    name: propertyMetadata.matsMethodDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.matsMethodDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.matsMethodDTOEndDate.description,
     example: propertyMetadata.matsMethodDTOEndDate.example,
-    name: propertyMetadata.matsMethodDTOEndDate.fieldLabels.value
+    name: propertyMetadata.matsMethodDTOEndDate.fieldLabels.value,
   })
   @IsOptional()
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.matsMethodDTOEndHour.description,
     example: propertyMetadata.matsMethodDTOEndHour.example,
-    name: propertyMetadata.matsMethodDTOEndHour.fieldLabels.value
+    name: propertyMetadata.matsMethodDTOEndHour.fieldLabels.value,
   })
   @IsOptional()
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/monitor-default-base.dto.ts
+++ b/src/dtos/monitor-default-base.dto.ts
@@ -1,88 +1,103 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 export class MonitorDefaultBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTOParameterCode.description,
     example: propertyMetadata.monitorDefaultDTOParameterCode.example,
-    name: propertyMetadata.monitorDefaultDTOParameterCode.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTOParameterCode.fieldLabels.value,
   })
   parameterCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTODefaultValue.description,
     example: propertyMetadata.monitorDefaultDTODefaultValue.example,
-    name: propertyMetadata.monitorDefaultDTODefaultValue.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTODefaultValue.fieldLabels.value,
   })
   defaultValue: number;
 
   @ApiProperty({
-    description: propertyMetadata.monitorDefaultDTODefaultUnitsOfMeasureCode.description,
-    example: propertyMetadata.monitorDefaultDTODefaultUnitsOfMeasureCode.example,
-    name: propertyMetadata.monitorDefaultDTODefaultUnitsOfMeasureCode.fieldLabels.value
+    description:
+      propertyMetadata.monitorDefaultDTODefaultUnitsOfMeasureCode.description,
+    example:
+      propertyMetadata.monitorDefaultDTODefaultUnitsOfMeasureCode.example,
+    name:
+      propertyMetadata.monitorDefaultDTODefaultUnitsOfMeasureCode.fieldLabels
+        .value,
   })
   defaultUnitsOfMeasureCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorDefaultDTODefaultPurposeCode.description,
+    description:
+      propertyMetadata.monitorDefaultDTODefaultPurposeCode.description,
     example: propertyMetadata.monitorDefaultDTODefaultPurposeCode.example,
-    name: propertyMetadata.monitorDefaultDTODefaultPurposeCode.fieldLabels.value
+    name:
+      propertyMetadata.monitorDefaultDTODefaultPurposeCode.fieldLabels.value,
   })
   defaultPurposeCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTOFuelCode.description,
     example: propertyMetadata.monitorDefaultDTOFuelCode.example,
-    name: propertyMetadata.monitorDefaultDTOFuelCode.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTOFuelCode.fieldLabels.value,
   })
   fuelCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorDefaultDTOOperatingConditionCode.description,
+    description:
+      propertyMetadata.monitorDefaultDTOOperatingConditionCode.description,
     example: propertyMetadata.monitorDefaultDTOOperatingConditionCode.example,
-    name: propertyMetadata.monitorDefaultDTOOperatingConditionCode.fieldLabels.value
+    name:
+      propertyMetadata.monitorDefaultDTOOperatingConditionCode.fieldLabels
+        .value,
   })
   operatingConditionCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorDefaultDTODefaultSourceCode.description,
+    description:
+      propertyMetadata.monitorDefaultDTODefaultSourceCode.description,
     example: propertyMetadata.monitorDefaultDTODefaultSourceCode.example,
-    name: propertyMetadata.monitorDefaultDTODefaultSourceCode.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTODefaultSourceCode.fieldLabels.value,
   })
   defaultSourceCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTOGroupId.description,
     example: propertyMetadata.monitorDefaultDTOGroupId.example,
-    name: propertyMetadata.monitorDefaultDTOGroupId.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTOGroupId.fieldLabels.value,
   })
   groupId: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTOBeginDate.description,
     example: propertyMetadata.monitorDefaultDTOBeginDate.example,
-    name: propertyMetadata.monitorDefaultDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTOBeginHour.description,
     example: propertyMetadata.monitorDefaultDTOBeginHour.example,
-    name: propertyMetadata.monitorDefaultDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTOEndDate.description,
     example: propertyMetadata.monitorDefaultDTOEndDate.example,
-    name: propertyMetadata.monitorDefaultDTOEndDate.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorDefaultDTOEndHour.description,
     example: propertyMetadata.monitorDefaultDTOEndHour.example,
-    name: propertyMetadata.monitorDefaultDTOEndHour.fieldLabels.value
+    name: propertyMetadata.monitorDefaultDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/monitor-formula-base.dto.ts
+++ b/src/dtos/monitor-formula-base.dto.ts
@@ -1,60 +1,65 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 export class MonitorFormulaBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOFormulaId.description,
     example: propertyMetadata.monitorFormulaDTOFormulaId.example,
-    name: propertyMetadata.monitorFormulaDTOFormulaId.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOFormulaId.fieldLabels.value,
   })
   formulaId: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOParameterCode.description,
     example: propertyMetadata.monitorFormulaDTOParameterCode.example,
-    name: propertyMetadata.monitorFormulaDTOParameterCode.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOParameterCode.fieldLabels.value,
   })
   parameterCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOFormulaCode.description,
     example: propertyMetadata.monitorFormulaDTOFormulaCode.example,
-    name: propertyMetadata.monitorFormulaDTOFormulaCode.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOFormulaCode.fieldLabels.value,
   })
   formulaCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOFormulaText.description,
     example: propertyMetadata.monitorFormulaDTOFormulaText.example,
-    name: propertyMetadata.monitorFormulaDTOFormulaText.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOFormulaText.fieldLabels.value,
   })
   formulaText: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOBeginDate.description,
     example: propertyMetadata.monitorFormulaDTOBeginDate.example,
-    name: propertyMetadata.monitorFormulaDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOBeginHour.description,
     example: propertyMetadata.monitorFormulaDTOBeginHour.example,
-    name: propertyMetadata.monitorFormulaDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOEndDate.description,
     example: propertyMetadata.monitorFormulaDTOEndDate.example,
-    name: propertyMetadata.monitorFormulaDTOEndDate.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorFormulaDTOEndHour.description,
     example: propertyMetadata.monitorFormulaDTOEndHour.example,
-    name: propertyMetadata.monitorFormulaDTOEndHour.fieldLabels.value
+    name: propertyMetadata.monitorFormulaDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/monitor-load-base.dto.ts
+++ b/src/dtos/monitor-load-base.dto.ts
@@ -1,88 +1,103 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 export class MonitorLoadBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTOMaximumLoadValue.description,
     example: propertyMetadata.monitorLoadDTOMaximumLoadValue.example,
-    name: propertyMetadata.monitorLoadDTOMaximumLoadValue.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTOMaximumLoadValue.fieldLabels.value,
   })
   maximumLoadValue: number;
 
   @ApiProperty({
-    description: propertyMetadata.monitorLoadDTOMaximumLoadUnitsOfMeasureCode.description,
-    example: propertyMetadata.monitorLoadDTOMaximumLoadUnitsOfMeasureCode.example,
-    name: propertyMetadata.monitorLoadDTOMaximumLoadUnitsOfMeasureCode.fieldLabels.value
+    description:
+      propertyMetadata.monitorLoadDTOMaximumLoadUnitsOfMeasureCode.description,
+    example:
+      propertyMetadata.monitorLoadDTOMaximumLoadUnitsOfMeasureCode.example,
+    name:
+      propertyMetadata.monitorLoadDTOMaximumLoadUnitsOfMeasureCode.fieldLabels
+        .value,
   })
   maximumLoadUnitsOfMeasureCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorLoadDTOLowerOperationBoundary.description,
+    description:
+      propertyMetadata.monitorLoadDTOLowerOperationBoundary.description,
     example: propertyMetadata.monitorLoadDTOLowerOperationBoundary.example,
-    name: propertyMetadata.monitorLoadDTOLowerOperationBoundary.fieldLabels.value
+    name:
+      propertyMetadata.monitorLoadDTOLowerOperationBoundary.fieldLabels.value,
   })
   lowerOperationBoundary: number;
 
   @ApiProperty({
-    description: propertyMetadata.monitorLoadDTOUpperOperationBoundary.description,
+    description:
+      propertyMetadata.monitorLoadDTOUpperOperationBoundary.description,
     example: propertyMetadata.monitorLoadDTOUpperOperationBoundary.example,
-    name: propertyMetadata.monitorLoadDTOUpperOperationBoundary.fieldLabels.value
+    name:
+      propertyMetadata.monitorLoadDTOUpperOperationBoundary.fieldLabels.value,
   })
   upperOperationBoundary: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTONormalLevelCode.description,
     example: propertyMetadata.monitorLoadDTONormalLevelCode.example,
-    name: propertyMetadata.monitorLoadDTONormalLevelCode.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTONormalLevelCode.fieldLabels.value,
   })
   normalLevelCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTOSecondLevelCode.description,
     example: propertyMetadata.monitorLoadDTOSecondLevelCode.example,
-    name: propertyMetadata.monitorLoadDTOSecondLevelCode.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTOSecondLevelCode.fieldLabels.value,
   })
   secondLevelCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorLoadDTOSecondNormalIndicator.description,
+    description:
+      propertyMetadata.monitorLoadDTOSecondNormalIndicator.description,
     example: propertyMetadata.monitorLoadDTOSecondNormalIndicator.example,
-    name: propertyMetadata.monitorLoadDTOSecondNormalIndicator.fieldLabels.value
+    name:
+      propertyMetadata.monitorLoadDTOSecondNormalIndicator.fieldLabels.value,
   })
   secondNormalIndicator: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTOLoadAnalysisDate.description,
     example: propertyMetadata.monitorLoadDTOLoadAnalysisDate.example,
-    name: propertyMetadata.monitorLoadDTOLoadAnalysisDate.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTOLoadAnalysisDate.fieldLabels.value,
   })
   loadAnalysisDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTOBeginDate.description,
     example: propertyMetadata.monitorLoadDTOBeginDate.example,
-    name: propertyMetadata.monitorLoadDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTOBeginHour.description,
     example: propertyMetadata.monitorLoadDTOBeginHour.example,
-    name: propertyMetadata.monitorLoadDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTOEndDate.description,
     example: propertyMetadata.monitorLoadDTOEndDate.example,
-    name: propertyMetadata.monitorLoadDTOEndDate.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorLoadDTOEndHour.description,
     example: propertyMetadata.monitorLoadDTOEndHour.example,
-    name: propertyMetadata.monitorLoadDTOEndHour.fieldLabels.value
+    name: propertyMetadata.monitorLoadDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/monitor-method-base.dto.ts
+++ b/src/dtos/monitor-method-base.dto.ts
@@ -1,4 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 import { IsOptional } from 'class-validator';
 
@@ -6,29 +7,33 @@ export class MonitorMethodBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorMethodDTOParameterCode.description,
     example: propertyMetadata.monitorMethodDTOParameterCode.example,
-    name: propertyMetadata.monitorMethodDTOParameterCode.fieldLabels.value
+    name: propertyMetadata.monitorMethodDTOParameterCode.fieldLabels.value,
   })
   parameterCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorMethodDTOMonitoringMethodCode.description,
+    description:
+      propertyMetadata.monitorMethodDTOMonitoringMethodCode.description,
     example: propertyMetadata.monitorMethodDTOMonitoringMethodCode.example,
-    name: propertyMetadata.monitorMethodDTOMonitoringMethodCode.fieldLabels.value
+    name:
+      propertyMetadata.monitorMethodDTOMonitoringMethodCode.fieldLabels.value,
   })
   monitoringMethodCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorMethodDTOSubstituteDataCode.description,
+    description:
+      propertyMetadata.monitorMethodDTOSubstituteDataCode.description,
     example: propertyMetadata.monitorMethodDTOSubstituteDataCode.example,
-    name: propertyMetadata.monitorMethodDTOSubstituteDataCode.fieldLabels.value
+    name: propertyMetadata.monitorMethodDTOSubstituteDataCode.fieldLabels.value,
   })
   @IsOptional()
   substituteDataCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorMethodDTOBypassApproachCode.description,
+    description:
+      propertyMetadata.monitorMethodDTOBypassApproachCode.description,
     example: propertyMetadata.monitorMethodDTOBypassApproachCode.example,
-    name: propertyMetadata.monitorMethodDTOBypassApproachCode.fieldLabels.value
+    name: propertyMetadata.monitorMethodDTOBypassApproachCode.fieldLabels.value,
   })
   @IsOptional()
   bypassApproachCode: string;
@@ -36,30 +41,34 @@ export class MonitorMethodBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorMethodDTOBeginDate.description,
     example: propertyMetadata.monitorMethodDTOBeginDate.example,
-    name: propertyMetadata.monitorMethodDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.monitorMethodDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorMethodDTOBeginHour.description,
     example: propertyMetadata.monitorMethodDTOBeginHour.example,
-    name: propertyMetadata.monitorMethodDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.monitorMethodDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorMethodDTOEndDate.description,
     example: propertyMetadata.monitorMethodDTOEndDate.example,
-    name: propertyMetadata.monitorMethodDTOEndDate.fieldLabels.value
+    name: propertyMetadata.monitorMethodDTOEndDate.fieldLabels.value,
   })
   @IsOptional()
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorMethodDTOEndHour.description,
     example: propertyMetadata.monitorMethodDTOEndHour.example,
-    name: propertyMetadata.monitorMethodDTOEndHour.fieldLabels.value
+    name: propertyMetadata.monitorMethodDTOEndHour.fieldLabels.value,
   })
   @IsOptional()
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/monitor-method-base.dto.ts
+++ b/src/dtos/monitor-method-base.dto.ts
@@ -1,8 +1,6 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { IsNotEmpty, ValidateIf, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
-import { IsOptional } from 'class-validator';
-
 export class MonitorMethodBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorMethodDTOParameterCode.description,

--- a/src/dtos/monitor-span-base.dto.ts
+++ b/src/dtos/monitor-span-base.dto.ts
@@ -1,119 +1,125 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 export class MonitorSpanBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOComponentTypeCode.description,
     example: propertyMetadata.monitorSpanDTOComponentTypeCode.example,
-    name: propertyMetadata.monitorSpanDTOComponentTypeCode.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOComponentTypeCode.fieldLabels.value,
   })
   componentTypeCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOSpanScaleCode.description,
     example: propertyMetadata.monitorSpanDTOSpanScaleCode.example,
-    name: propertyMetadata.monitorSpanDTOSpanScaleCode.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOSpanScaleCode.fieldLabels.value,
   })
   spanScaleCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOSpanMethodCode.description,
     example: propertyMetadata.monitorSpanDTOSpanMethodCode.example,
-    name: propertyMetadata.monitorSpanDTOSpanMethodCode.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOSpanMethodCode.fieldLabels.value,
   })
   spanMethodCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOMecValue.description,
     example: propertyMetadata.monitorSpanDTOMecValue.example,
-    name: propertyMetadata.monitorSpanDTOMecValue.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOMecValue.fieldLabels.value,
   })
   mecValue: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOMpcValue.description,
     example: propertyMetadata.monitorSpanDTOMpcValue.example,
-    name: propertyMetadata.monitorSpanDTOMpcValue.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOMpcValue.fieldLabels.value,
   })
   mpcValue: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOMpfValue.description,
     example: propertyMetadata.monitorSpanDTOMpfValue.example,
-    name: propertyMetadata.monitorSpanDTOMpfValue.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOMpfValue.fieldLabels.value,
   })
   mpfValue: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOSpanValue.description,
     example: propertyMetadata.monitorSpanDTOSpanValue.example,
-    name: propertyMetadata.monitorSpanDTOSpanValue.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOSpanValue.fieldLabels.value,
   })
   spanValue: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOFullScaleRange.description,
     example: propertyMetadata.monitorSpanDTOFullScaleRange.example,
-    name: propertyMetadata.monitorSpanDTOFullScaleRange.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOFullScaleRange.fieldLabels.value,
   })
   fullScaleRange: number;
 
   @ApiProperty({
-    description: propertyMetadata.monitorSpanDTOSpanUnitsOfMeasureCode.description,
+    description:
+      propertyMetadata.monitorSpanDTOSpanUnitsOfMeasureCode.description,
     example: propertyMetadata.monitorSpanDTOSpanUnitsOfMeasureCode.example,
-    name: propertyMetadata.monitorSpanDTOSpanUnitsOfMeasureCode.fieldLabels.value
+    name:
+      propertyMetadata.monitorSpanDTOSpanUnitsOfMeasureCode.fieldLabels.value,
   })
   spanUnitsOfMeasureCode: string;
-
 
   scaleTransitionPoint: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTODefaultHighRange.description,
     example: propertyMetadata.monitorSpanDTODefaultHighRange.example,
-    name: propertyMetadata.monitorSpanDTODefaultHighRange.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTODefaultHighRange.fieldLabels.value,
   })
   defaultHighRange: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOFlowSpanValue.description,
     example: propertyMetadata.monitorSpanDTOFlowSpanValue.example,
-    name: propertyMetadata.monitorSpanDTOFlowSpanValue.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOFlowSpanValue.fieldLabels.value,
   })
   flowSpanValue: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOFlowFullScaleRange.description,
     example: propertyMetadata.monitorSpanDTOFlowFullScaleRange.example,
-    name: propertyMetadata.monitorSpanDTOFlowFullScaleRange.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOFlowFullScaleRange.fieldLabels.value,
   })
   flowFullScaleRange: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOBeginDate.description,
     example: propertyMetadata.monitorSpanDTOBeginDate.example,
-    name: propertyMetadata.monitorSpanDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOBeginHour.description,
     example: propertyMetadata.monitorSpanDTOBeginHour.example,
-    name: propertyMetadata.monitorSpanDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOEndDate.description,
     example: propertyMetadata.monitorSpanDTOEndDate.example,
-    name: propertyMetadata.monitorSpanDTOEndDate.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOEndHour.description,
     example: propertyMetadata.monitorSpanDTOEndHour.example,
-    name: propertyMetadata.monitorSpanDTOEndHour.fieldLabels.value
+    name: propertyMetadata.monitorSpanDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/monitor-system-base.dto.ts
+++ b/src/dtos/monitor-system-base.dto.ts
@@ -1,61 +1,68 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
-
 
 export class MonitorSystemBaseDTO {
   @ApiProperty({
-    description: propertyMetadata.monitorSystemDTOMonitoringSystemId.description,
+    description:
+      propertyMetadata.monitorSystemDTOMonitoringSystemId.description,
     example: propertyMetadata.monitorSystemDTOMonitoringSystemId.example,
-    name: propertyMetadata.monitorSystemDTOMonitoringSystemId.fieldLabels.value
+    name: propertyMetadata.monitorSystemDTOMonitoringSystemId.fieldLabels.value,
   })
   monitoringSystemId: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOSystemTypeCode.description,
     example: propertyMetadata.monitorSystemDTOSystemTypeCode.example,
-    name: propertyMetadata.monitorSystemDTOSystemTypeCode.fieldLabels.value
+    name: propertyMetadata.monitorSystemDTOSystemTypeCode.fieldLabels.value,
   })
   systemTypeCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.monitorSystemDTOSystemDesignationCode.description,
+    description:
+      propertyMetadata.monitorSystemDTOSystemDesignationCode.description,
     example: propertyMetadata.monitorSystemDTOSystemDesignationCode.example,
-    name: propertyMetadata.monitorSystemDTOSystemDesignationCode.fieldLabels.value
+    name:
+      propertyMetadata.monitorSystemDTOSystemDesignationCode.fieldLabels.value,
   })
   systemDesignationCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOFuelCode.description,
     example: propertyMetadata.monitorSystemDTOFuelCode.example,
-    name: propertyMetadata.monitorSystemDTOFuelCode.fieldLabels.value
+    name: propertyMetadata.monitorSystemDTOFuelCode.fieldLabels.value,
   })
   fuelCode: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOBeginDate.description,
     example: propertyMetadata.monitorSystemDTOBeginDate.example,
-    name: propertyMetadata.monitorSystemDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.monitorSystemDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOEndDate.description,
     example: propertyMetadata.monitorSystemDTOEndDate.example,
-    name: propertyMetadata.monitorSystemDTOEndDate.fieldLabels.value
+    name: propertyMetadata.monitorSystemDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOBeginHour.description,
     example: propertyMetadata.monitorSystemDTOBeginHour.example,
-    name: propertyMetadata.monitorSystemDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.monitorSystemDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOEndHour.description,
     example: propertyMetadata.monitorSystemDTOEndHour.example,
-    name: propertyMetadata.monitorSystemDTOEndHour.fieldLabels.value
+    name: propertyMetadata.monitorSystemDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/system-component-base.dto.ts
+++ b/src/dtos/system-component-base.dto.ts
@@ -1,4 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 import { ComponentBaseDTO } from './component-base.dto';
 
@@ -6,28 +7,32 @@ export class SystemComponentBaseDTO extends ComponentBaseDTO {
   @ApiProperty({
     description: propertyMetadata.systemComponentDTOBeginDate.description,
     example: propertyMetadata.systemComponentDTOBeginDate.example,
-    name: propertyMetadata.systemComponentDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.systemComponentDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.systemComponentDTOBeginHour.description,
     example: propertyMetadata.systemComponentDTOBeginHour.example,
-    name: propertyMetadata.systemComponentDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.systemComponentDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.systemComponentDTOEndDate.description,
     example: propertyMetadata.systemComponentDTOEndDate.example,
-    name: propertyMetadata.systemComponentDTOEndDate.fieldLabels.value
+    name: propertyMetadata.systemComponentDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.systemComponentDTOEndHour.description,
     example: propertyMetadata.systemComponentDTOEndHour.example,
-    name: propertyMetadata.systemComponentDTOEndHour.fieldLabels.value
+    name: propertyMetadata.systemComponentDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/dtos/system-fuel-flow-base.dto.ts
+++ b/src/dtos/system-fuel-flow-base.dto.ts
@@ -1,53 +1,67 @@
-import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, ValidateIf } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 export class SystemFuelFlowBaseDTO {
   @ApiProperty({
-    description: propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRate.description,
+    description:
+      propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRate.description,
     example: propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRate.example,
-    name: propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRate.fieldLabels.value
+    name:
+      propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRate.fieldLabels.value,
   })
   maximumFuelFlowRate: number;
 
   @ApiProperty({
-    description: propertyMetadata.systemFuelFlowDTOSystemFuelFlowUOMCode.description,
+    description:
+      propertyMetadata.systemFuelFlowDTOSystemFuelFlowUOMCode.description,
     example: propertyMetadata.systemFuelFlowDTOSystemFuelFlowUOMCode.example,
-    name: propertyMetadata.systemFuelFlowDTOSystemFuelFlowUOMCode.fieldLabels.value
+    name:
+      propertyMetadata.systemFuelFlowDTOSystemFuelFlowUOMCode.fieldLabels.value,
   })
   systemFuelFlowUOMCode: string;
 
   @ApiProperty({
-    description: propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRateSourceCode.description,
-    example: propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRateSourceCode.example,
-    name: propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRateSourceCode.fieldLabels.value
+    description:
+      propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRateSourceCode
+        .description,
+    example:
+      propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRateSourceCode.example,
+    name:
+      propertyMetadata.systemFuelFlowDTOMaximumFuelFlowRateSourceCode
+        .fieldLabels.value,
   })
   maximumFuelFlowRateSourceCode: string;
 
   @ApiProperty({
     description: propertyMetadata.systemFuelFlowDTOBeginDate.description,
     example: propertyMetadata.systemFuelFlowDTOBeginDate.example,
-    name: propertyMetadata.systemFuelFlowDTOBeginDate.fieldLabels.value
+    name: propertyMetadata.systemFuelFlowDTOBeginDate.fieldLabels.value,
   })
   beginDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.systemFuelFlowDTOBeginHour.description,
     example: propertyMetadata.systemFuelFlowDTOBeginHour.example,
-    name: propertyMetadata.systemFuelFlowDTOBeginHour.fieldLabels.value
+    name: propertyMetadata.systemFuelFlowDTOBeginHour.fieldLabels.value,
   })
   beginHour: number;
 
   @ApiProperty({
     description: propertyMetadata.systemFuelFlowDTOEndDate.description,
     example: propertyMetadata.systemFuelFlowDTOEndDate.example,
-    name: propertyMetadata.systemFuelFlowDTOEndDate.fieldLabels.value
+    name: propertyMetadata.systemFuelFlowDTOEndDate.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @ApiProperty({
     description: propertyMetadata.systemFuelFlowDTOEndHour.description,
     example: propertyMetadata.systemFuelFlowDTOEndHour.example,
-    name: propertyMetadata.systemFuelFlowDTOEndHour.fieldLabels.value
+    name: propertyMetadata.systemFuelFlowDTOEndHour.fieldLabels.value,
   })
+  @IsNotEmpty()
+  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 }

--- a/src/duct-waf-workspace/duct-waf.service.ts
+++ b/src/duct-waf-workspace/duct-waf.service.ts
@@ -10,7 +10,6 @@ import { DuctWaf } from '../entities/duct-waf.entity';
 import { DuctWafWorkspaceRepository } from './duct-waf.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class DuctWafWorkspaceService {
@@ -65,7 +64,6 @@ export class DuctWafWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(ductWaf);
     await this.repository.save(ductWaf);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(ductWaf);
@@ -95,7 +93,6 @@ export class DuctWafWorkspaceService {
     ductWaf.userId = userId;
     ductWaf.updateDate = new Date(Date.now());
 
-    await validateObject(ductWaf);
     await this.repository.save(ductWaf);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(ductWaf);

--- a/src/entities/workspace/analyzer-range.entity.ts
+++ b/src/entities/workspace/analyzer-range.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -38,16 +37,12 @@ export class AnalyzerRange extends BaseEntity {
   beginDate: Date;
 
   @Column({ type: 'date', nullable: true, name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ name: 'begin_hour' })
   beginHour: number;
 
   @Column({ name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({

--- a/src/entities/workspace/duct-waf.entity.ts
+++ b/src/entities/workspace/duct-waf.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Column,
@@ -93,8 +92,6 @@ export class DuctWaf extends BaseEntity {
   ductDepth: number;
 
   @Column({ type: 'date', name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.wafEndHour !== null)
   wafEndDate: Date;
 
   @Column({
@@ -104,8 +101,6 @@ export class DuctWaf extends BaseEntity {
     nullable: true,
     name: 'end_hour',
   })
-  @IsNotEmpty()
-  @ValidateIf(o => o.wafEndDate !== null)
   wafEndHour: number;
 
   @Column({ type: 'varchar', length: 8, name: 'userid' })

--- a/src/entities/workspace/mats-method.entity.ts
+++ b/src/entities/workspace/mats-method.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -41,13 +40,9 @@ export class MatsMethod extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', nullable: true, name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ nullable: true, name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({ type: 'varchar', nullable: true, length: 8, name: 'userid' })

--- a/src/entities/workspace/monitor-default.entity.ts
+++ b/src/entities/workspace/monitor-default.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Column,
@@ -66,13 +65,9 @@ export class MonitorDefault extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ type: 'numeric', precision: 2, scale: 0, name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({ type: 'varchar', length: 8, name: 'userid' })

--- a/src/entities/workspace/monitor-formula.entity.ts
+++ b/src/entities/workspace/monitor-formula.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -39,13 +38,9 @@ export class MonitorFormula extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', nullable: true, name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ nullable: true, name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({

--- a/src/entities/workspace/monitor-load.entity.ts
+++ b/src/entities/workspace/monitor-load.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -28,13 +27,9 @@ export class MonitorLoad extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', nullable: true, name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ nullable: true, name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({ nullable: true, name: 'max_load_value' })

--- a/src/entities/workspace/monitor-method.entity.ts
+++ b/src/entities/workspace/monitor-method.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -42,13 +41,9 @@ export class MonitorMethod extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({ type: 'varchar', nullable: true, length: 8, name: 'userid' })

--- a/src/entities/workspace/monitor-span.entity.ts
+++ b/src/entities/workspace/monitor-span.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -94,13 +93,9 @@ export class MonitorSpan extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ type: 'numeric', precision: 2, scale: 0, name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({ type: 'varchar', length: 8, name: 'userid' })

--- a/src/entities/workspace/monitor-system.entity.ts
+++ b/src/entities/workspace/monitor-system.entity.ts
@@ -14,7 +14,6 @@ import { Component } from './component.entity';
 import { SystemComponent } from './system-component.entity';
 import { SystemFuelFlow } from './system-fuel-flow.entity';
 import { MonitorLocation } from './monitor-location.entity';
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 
 @Entity({ name: 'camdecmpswks.monitor_system' })
 export class MonitorSystem extends BaseEntity {
@@ -50,16 +49,12 @@ export class MonitorSystem extends BaseEntity {
   beginDate: Date;
 
   @Column({ type: 'date', nullable: true, name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ name: 'begin_hour' })
   beginHour: number;
 
   @Column({ name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({ type: 'varchar', length: 8, name: 'userid' })

--- a/src/entities/workspace/system-component.entity.ts
+++ b/src/entities/workspace/system-component.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -40,13 +39,9 @@ export class SystemComponent extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ type: 'numeric', precision: 2, scale: 0, name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({

--- a/src/entities/workspace/system-fuel-flow.entity.ts
+++ b/src/entities/workspace/system-fuel-flow.entity.ts
@@ -1,4 +1,3 @@
-import { IsNotEmpty, ValidateIf } from 'class-validator';
 import {
   BaseEntity,
   Entity,
@@ -49,13 +48,9 @@ export class SystemFuelFlow extends BaseEntity {
   beginHour: number;
 
   @Column({ type: 'date', name: 'end_date' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endHour !== null)
   endDate: Date;
 
   @Column({ type: 'numeric', precision: 2, scale: 0, name: 'end_hour' })
-  @IsNotEmpty()
-  @ValidateIf(o => o.endDate !== null)
   endHour: number;
 
   @Column({ type: 'varchar', length: 8, name: 'userid' })

--- a/src/mats-method-workspace/mats-method.service.ts
+++ b/src/mats-method-workspace/mats-method.service.ts
@@ -9,7 +9,6 @@ import { MatsMethod } from '../entities/workspace/mats-method.entity';
 import { UpdateMatsMethodDTO } from '../dtos/mats-method-update.dto';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class MatsMethodWorkspaceService {
@@ -58,7 +57,6 @@ export class MatsMethodWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(method);
     await this.repository.save(method);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(method);
@@ -83,7 +81,6 @@ export class MatsMethodWorkspaceService {
     method.userId = userId;
     method.updateDate = new Date(Date.now());
 
-    await validateObject(method);
     await this.repository.save(method);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(method);

--- a/src/monitor-default-workspace/monitor-default.service.ts
+++ b/src/monitor-default-workspace/monitor-default.service.ts
@@ -9,7 +9,6 @@ import { MonitorDefault } from '../entities/workspace/monitor-default.entity';
 import { UpdateMonitorDefaultDTO } from '../dtos/monitor-default-update.dto';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class MonitorDefaultWorkspaceService {
@@ -67,7 +66,6 @@ export class MonitorDefaultWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(monDefault);
     await this.repository.save(monDefault);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(monDefault);
@@ -96,7 +94,6 @@ export class MonitorDefaultWorkspaceService {
     monDefault.userId = userId;
     monDefault.updateDate = new Date(Date.now());
 
-    await validateObject(monDefault);
     await this.repository.save(monDefault);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(monDefault);

--- a/src/monitor-formula-workspace/monitor-formula.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula.service.ts
@@ -9,7 +9,6 @@ import { MonitorFormulaDTO } from '../dtos/monitor-formula.dto';
 import { MonitorFormulaMap } from '../maps/monitor-formula.map';
 import { MonitorFormula } from '../entities/workspace/monitor-formula.entity';
 import { MonitorFormulaWorkspaceRepository } from './monitor-formula.repository';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class MonitorFormulaWorkspaceService {
@@ -66,7 +65,6 @@ export class MonitorFormulaWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(formula);
     await this.repository.save(formula);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(formula);
@@ -91,7 +89,6 @@ export class MonitorFormulaWorkspaceService {
     formula.userId = userId;
     formula.updateDate = new Date(Date.now());
 
-    await validateObject(formula);
     await this.repository.save(formula);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(formula);

--- a/src/monitor-load-workspace/monitor-load.service.ts
+++ b/src/monitor-load-workspace/monitor-load.service.ts
@@ -9,7 +9,6 @@ import { MonitorLoadWorkspaceRepository } from './monitor-load.repository';
 import { MonitorLoad } from '../entities/workspace/monitor-load.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class MonitorLoadWorkspaceService {
@@ -63,8 +62,6 @@ export class MonitorLoadWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    // Validate load
-    await validateObject(load);
     await this.repository.save(load);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(load);
@@ -93,7 +90,6 @@ export class MonitorLoadWorkspaceService {
     load.userId = userId;
     load.updateDate = new Date(Date.now());
 
-    await validateObject(load);
     await this.repository.save(load);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(load);

--- a/src/monitor-method-workspace/monitor-method.service.ts
+++ b/src/monitor-method-workspace/monitor-method.service.ts
@@ -9,7 +9,6 @@ import { MonitorMethod } from '../entities/workspace/monitor-method.entity';
 import { MonitorMethodWorkspaceRepository } from './monitor-method.repository';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class MonitorMethodWorkspaceService {
@@ -59,7 +58,6 @@ export class MonitorMethodWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(monMethod);
     await this.repository.save(monMethod);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(monMethod);
@@ -84,7 +82,6 @@ export class MonitorMethodWorkspaceService {
     method.userId = userId;
     method.updateDate = new Date(Date.now());
 
-    await validateObject(method);
     await this.repository.save(method);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(method);

--- a/src/monitor-span-workspace/monitor-span.service.ts
+++ b/src/monitor-span-workspace/monitor-span.service.ts
@@ -9,7 +9,6 @@ import { MonitorSpanDTO } from '../dtos/monitor-span.dto';
 import { MonitorSpanMap } from '../maps/monitor-span.map';
 import { MonitorSpan } from '../entities/workspace/monitor-span.entity';
 import { MonitorSpanWorkspaceRepository } from './monitor-span.repository';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class MonitorSpanWorkspaceService {
@@ -69,7 +68,6 @@ export class MonitorSpanWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(span);
     await this.repository.save(span);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(span);
@@ -103,7 +101,6 @@ export class MonitorSpanWorkspaceService {
     span.userId = userId;
     span.updateDate = new Date(Date.now());
 
-    await validateObject(span);
     await this.repository.save(span);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(span);

--- a/src/monitor-system-workspace/monitor-system.service.ts
+++ b/src/monitor-system-workspace/monitor-system.service.ts
@@ -9,7 +9,6 @@ import { MonitorSystemWorkspaceRepository } from './monitor-system.repository';
 import { MonitorSystem } from '../entities/monitor-system.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class MonitorSystemWorkspaceService {
@@ -54,7 +53,6 @@ export class MonitorSystemWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(system);
     await this.repository.save(system);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
     return this.map.one(system);
@@ -90,7 +88,6 @@ export class MonitorSystemWorkspaceService {
     system.userId = userId;
     system.updateDate = new Date(Date.now());
 
-    await validateObject(system);
     await this.repository.save(system);
     await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(system);

--- a/src/system-component-workspace/system-component.service.ts
+++ b/src/system-component-workspace/system-component.service.ts
@@ -12,7 +12,6 @@ import { ComponentWorkspaceService } from '../component-workspace/component.serv
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class SystemComponentWorkspaceService {
@@ -99,7 +98,6 @@ export class SystemComponentWorkspaceService {
     component.userId = userId;
     component.updateDate = new Date(Date.now());
 
-    await validateObject(systemComponent);
     await this.repository.save(systemComponent);
     await this.compRepository.save(component);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);
@@ -149,7 +147,6 @@ export class SystemComponentWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(systemComponent);
     await this.repository.save(systemComponent);
     await this.compRepository.save(component);
     await this.mpService.resetToNeedsEvaluation(locationId, userId);

--- a/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
@@ -10,7 +10,6 @@ import { SystemFuelFlow } from '../entities/system-fuel-flow.entity';
 import { UpdateSystemFuelFlowDTO } from '../dtos/system-fuel-flow-update.dto';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { validateObject } from '../utils';
 
 @Injectable()
 export class SystemFuelFlowWorkspaceService {
@@ -60,7 +59,6 @@ export class SystemFuelFlowWorkspaceService {
       updateDate: new Date(Date.now()),
     });
 
-    await validateObject(fuelFlow);
     await this.repository.save(fuelFlow);
     await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(fuelFlow);
@@ -83,7 +81,6 @@ export class SystemFuelFlowWorkspaceService {
     fuelFlow.beginHour = payload.beginHour;
     fuelFlow.endHour = payload.endHour;
 
-    await validateObject(fuelFlow);
     await this.repository.save(fuelFlow);
     await this.mpService.resetToNeedsEvaluation(locId, userId);
     return this.map.one(fuelFlow);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,3 @@
-import { BadRequestException } from '@nestjs/common';
-import { Logger } from '@nestjs/common/services/logger.service';
-import { validate } from 'class-validator';
-
 export const parseToken = (token: string) => {
   const obj = {
     userId: null,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,23 +18,3 @@ export const parseToken = (token: string) => {
 
   return obj;
 };
-
-export const validateObject = async object => {
-  const errors = await validate(object);
-  // If validation passes...
-  if (!errors || errors.length <= 0) {
-    // continue to update logic in the current module's service
-    return;
-  }
-
-  // If validation fails...
-  else {
-    // Log the errors
-    const errMsg =
-      'Validation failed: you must include values for both End Date and End Hour fields. Otherwise, both fields must be empty in the payload.';
-    Logger.error(BadRequestException, errMsg, true, {
-      id: object,
-    });
-    throw new BadRequestException(errMsg);
-  }
-};


### PR DESCRIPTION
Moved validation from entity to DTO level for the following files:
- analyzer-range.entity -> analyzer-range-base.dto
- duct-waf.entity -> duct-waf-base.dto
- mats-method.entity -> mats-method-base.dto
- monitor-default.entity -> monitor-default-base.dto
- monitor-formula.entity -> monitor-formula-base.dto
- monitor-load.entity -> monitor-load-base.dto
- monitor-method.entity -> monitor-method-base.dto
- monitor-span.entity -> monitor-span-base.dto
- monitor-system.entity -> monitor-system-base.dto
- system-component.entity -> system-component-base.dto
- system-fuel-flow.entity -> system-fuel-flow-base.dto