### PR TITLE
Feature/3660: Add "stackPipeRecordId" and "beginReportPeriodId" to Configurations

### DIFF
--- a/src/dtos/monitor-location.dto.ts
+++ b/src/dtos/monitor-location.dto.ts
@@ -32,6 +32,13 @@ export class MonitorLocationDTO extends MonitorLocationBaseDTO {
   unitRecordId: number;
 
   @ApiProperty({
+    description:
+      propertyMetadata.unitStackConfigurationDTOStackPipeId.description,
+    example: propertyMetadata.unitStackConfigurationDTOStackPipeId.example,
+  })
+  stackPipeRecordId: string;
+
+  @ApiProperty({
     description: propertyMetadata.monitorLocationDTOName.description,
     example: propertyMetadata.monitorLocationDTOName.example,
     name: propertyMetadata.monitorLocationDTOName.fieldLabels.value,

--- a/src/dtos/monitor-plan-update.dto.ts
+++ b/src/dtos/monitor-plan-update.dto.ts
@@ -34,7 +34,7 @@ export class UpdateMonitorPlanDTO {
 
   @ValidateNested()
   @Type(() => UnitStackConfigurationBaseDTO)
-  unitStackConfiguration: UnitStackConfigurationBaseDTO[];
+  unitStackConfigurations: UnitStackConfigurationBaseDTO[];
 
   @ValidateNested()
   @Type(() => UpdateMonitorLocationDTO)

--- a/src/dtos/monitor-plan.dto.ts
+++ b/src/dtos/monitor-plan.dto.ts
@@ -38,6 +38,7 @@ export class MonitorPlanDTO {
     example: propertyMetadata.monitorPlanDTOEndReportPeriodId.example,
     name: propertyMetadata.monitorPlanDTOEndReportPeriodId.fieldLabels.value,
   })
+  beginReportPeriodId: number;
   endReportPeriodId: number;
   active: boolean;
   comments: MonitorPlanCommentDTO[];

--- a/src/dtos/monitor-plan.dto.ts
+++ b/src/dtos/monitor-plan.dto.ts
@@ -42,7 +42,7 @@ export class MonitorPlanDTO {
   endReportPeriodId: number;
   active: boolean;
   comments: MonitorPlanCommentDTO[];
-  unitStackConfiguration: UnitStackConfigurationDTO[];
+  unitStackConfigurations: UnitStackConfigurationDTO[];
   locations: MonitorLocationDTO[];
   evalStatusCode: string;
   userId: string;

--- a/src/entities/monitor-plan.entity.ts
+++ b/src/entities/monitor-plan.entity.ts
@@ -101,5 +101,5 @@ export class MonitorPlan extends BaseEntity {
     comment => comment.plan,
   )
   comments: MonitorPlanComment[];
-  unitStackConfiguration: UnitStackConfiguration[];
+  unitStackConfigurations: UnitStackConfiguration[];
 }

--- a/src/entities/monitor-plan.entity.ts
+++ b/src/entities/monitor-plan.entity.ts
@@ -13,6 +13,7 @@ import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import { Plant } from './plant.entity';
 import { MonitorLocation } from './monitor-location.entity';
 import { MonitorPlanComment } from './monitor-plan-comment.entity';
+import { UnitStackConfiguration } from './unit-stack-configuration.entity';
 
 @Entity({ name: 'camdecmps.monitor_plan' })
 export class MonitorPlan extends BaseEntity {
@@ -100,4 +101,5 @@ export class MonitorPlan extends BaseEntity {
     comment => comment.plan,
   )
   comments: MonitorPlanComment[];
+  unitStackConfiguration: UnitStackConfiguration[];
 }

--- a/src/entities/monitor-plan.entity.ts
+++ b/src/entities/monitor-plan.entity.ts
@@ -41,6 +41,15 @@ export class MonitorPlan extends BaseEntity {
   })
   endReportPeriodId: number;
 
+  @Column({
+    type: 'numeric',
+    precision: 38,
+    scale: 0,
+    name: 'begin_rpt_period_id',
+    transformer: new NumericColumnTransformer(),
+  })
+  beginReportPeriodId: number;
+
   // pointing to needs_eval_flg because there is no eval_status_cd column in global view
   @Column({
     type: 'varchar',

--- a/src/entities/workspace/monitor-plan.entity.ts
+++ b/src/entities/workspace/monitor-plan.entity.ts
@@ -42,6 +42,15 @@ export class MonitorPlan extends BaseEntity {
   endReportPeriodId: number;
 
   @Column({
+    type: 'numeric',
+    precision: 38,
+    scale: 0,
+    name: 'begin_rpt_period_id',
+    transformer: new NumericColumnTransformer(),
+  })
+  beginReportPeriodId: number;
+
+  @Column({
     type: 'varchar',
     length: 7,
     name: 'eval_status_cd',

--- a/src/entities/workspace/monitor-plan.entity.ts
+++ b/src/entities/workspace/monitor-plan.entity.ts
@@ -101,5 +101,5 @@ export class MonitorPlan extends BaseEntity {
   )
   comments: MonitorPlanComment[];
 
-  unitStackConfiguration: UnitStackConfiguration[];
+  unitStackConfigurations: UnitStackConfiguration[];
 }

--- a/src/entities/workspace/monitor-plan.entity.ts
+++ b/src/entities/workspace/monitor-plan.entity.ts
@@ -13,6 +13,7 @@ import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import { Plant } from './plant.entity';
 import { MonitorLocation } from './monitor-location.entity';
 import { MonitorPlanComment } from './monitor-plan-comment.entity';
+import { UnitStackConfiguration } from './unit-stack-configuration.entity';
 
 @Entity({ name: 'camdecmpswks.monitor_plan' })
 export class MonitorPlan extends BaseEntity {
@@ -36,19 +37,19 @@ export class MonitorPlan extends BaseEntity {
     type: 'numeric',
     precision: 38,
     scale: 0,
-    name: 'end_rpt_period_id',
+    name: 'begin_rpt_period_id',
     transformer: new NumericColumnTransformer(),
   })
-  endReportPeriodId: number;
+  beginReportPeriodId: number;
 
   @Column({
     type: 'numeric',
     precision: 38,
     scale: 0,
-    name: 'begin_rpt_period_id',
+    name: 'end_rpt_period_id',
     transformer: new NumericColumnTransformer(),
   })
-  beginReportPeriodId: number;
+  endReportPeriodId: number;
 
   @Column({
     type: 'varchar',
@@ -99,4 +100,6 @@ export class MonitorPlan extends BaseEntity {
     comment => comment.plan,
   )
   comments: MonitorPlanComment[];
+
+  unitStackConfiguration: UnitStackConfiguration[];
 }

--- a/src/import-checks/mp-file-checks/formula.spec.ts
+++ b/src/import-checks/mp-file-checks/formula.spec.ts
@@ -4,7 +4,7 @@ import { UpdateMonitorPlanDTO } from '../../dtos/monitor-plan-update.dto';
 import { MonitorLocation } from '../../entities/workspace/monitor-location.entity';
 import { UpdateMonitorLocationDTO } from '../../dtos/monitor-location-update.dto';
 import { MonitorFormula } from '../../entities/workspace/monitor-formula.entity';
-import { MonitorFormulaBaseDTO } from '../../dtos/monitor-formula-update.dto';
+import { MonitorFormulaBaseDTO } from '../../dtos/monitor-formula.dto';
 
 describe('Component Tests', () => {
   describe('Check9', () => {

--- a/src/import-checks/mp-file-checks/qual.spec.ts
+++ b/src/import-checks/mp-file-checks/qual.spec.ts
@@ -1,9 +1,9 @@
 import * as checks from './qual';
 import { UpdateMonitorPlanDTO } from '../../dtos/monitor-plan-update.dto';
 import { UpdateMonitorLocationDTO } from '../../dtos/monitor-location-update.dto';
-import { MonitorQualificationBaseDTO } from '../../dtos/monitor-qualification-update.dto';
-import { LMEQualificationBaseDTO } from '../../dtos/lme-qualification-update.dto';
-import { PCTQualificationBaseDTO } from '../../dtos/pct-qualification-update.dto';
+import { MonitorQualificationBaseDTO } from '../../dtos/monitor-qualification.dto';
+import { LMEQualificationBaseDTO } from '../../dtos/lme-qualification.dto';
+import { PCTQualificationBaseDTO } from '../../dtos/pct-qualification.dto';
 
 describe('Span Tests', () => {
   describe('Check11', () => {

--- a/src/import-checks/mp-file-checks/span.spec.ts
+++ b/src/import-checks/mp-file-checks/span.spec.ts
@@ -1,7 +1,7 @@
 import * as checks from './span';
 import { UpdateMonitorPlanDTO } from '../../dtos/monitor-plan-update.dto';
 import { UpdateMonitorLocationDTO } from '../../dtos/monitor-location-update.dto';
-import { MonitorSpanBaseDTO } from '../../dtos/monitor-span-update.dto';
+import { MonitorSpanBaseDTO } from '../../dtos/monitor-span.dto';
 
 describe('Span Tests', () => {
   describe('Check10', () => {

--- a/src/maps/monitor-location.map.ts
+++ b/src/maps/monitor-location.map.ts
@@ -69,6 +69,7 @@ export class MonitorLocationMap extends BaseMap<
     let retireDate: Date;
     let stackPipeId: string;
     let unitRecordId: number;
+    let stackPipeRecordId: string;
     let nonLoadBasedIndicator: number;
     let unitCapacities = [];
     let unitControls = [];
@@ -109,6 +110,7 @@ export class MonitorLocationMap extends BaseMap<
       name = entity.unit.name;
       unitId = entity.unit.name;
       unitRecordId = entity.unit.id;
+      stackPipeRecordId = null;
       nonLoadBasedIndicator = entity.unit.nonLoadBasedIndicator;
       stackPipeId = null;
       activeDate = null;
@@ -127,6 +129,7 @@ export class MonitorLocationMap extends BaseMap<
     if (entity.stackPipe) {
       type = 'stack';
       name = entity.stackPipe.name;
+      stackPipeRecordId = entity.stackPipe.id;
       stackPipeId = entity.stackPipe.name;
       activeDate = entity.stackPipe.activeDate;
       retireDate = entity.stackPipe.retireDate;
@@ -139,6 +142,7 @@ export class MonitorLocationMap extends BaseMap<
       id: entity.id,
       unitRecordId,
       unitId,
+      stackPipeRecordId,
       stackPipeId,
       name,
       type,

--- a/src/maps/monitor-plan.map.spec.ts
+++ b/src/maps/monitor-plan.map.spec.ts
@@ -20,15 +20,20 @@ import { LEEQualificationMap } from './lee-qualification.map';
 import { LMEQualificationMap } from './lme-qualification.map';
 import { PCTQualificationMap } from './pct-qualification.map';
 import { Plant } from '../entities/plant.entity';
+import { MonitorPlanCommentMap } from './monitor-plan-comment.map';
+import { UnitCapacityMap } from './unit-capacity.map';
+import { UnitControlMap } from './unit-control.map';
+import { UnitFuelMap } from './unit-fuel.map';
 
 const id = '';
 const facId = 0;
 const orisCode = 0;
 const name = '';
 const endReportPeriodId = 0;
+const beginReportPeriodId = 1;
 const active = false;
-const comments = null;
-const unitStackConfiguration = null;
+const comments = [];
+const unitStackConfiguration = [];
 const locations = [];
 const evalStatusCode = '';
 const userId = '';
@@ -42,6 +47,7 @@ plant.orisCode = orisCode;
 
 entity.id = id;
 entity.facId = facId;
+entity.beginReportPeriodId = beginReportPeriodId;
 entity.endReportPeriodId = endReportPeriodId;
 entity.comments = comments;
 entity.locations = locations;
@@ -69,6 +75,7 @@ describe('MonitorPlanMap', () => {
         MonitorLoadMap,
         ComponentMap,
         MonitorSystemMap,
+        MonitorPlanCommentMap,
         MonitorQualificationMap,
         MonitorAttributeMap,
         AnalyzerRangeMap,
@@ -77,6 +84,9 @@ describe('MonitorPlanMap', () => {
         LEEQualificationMap,
         LMEQualificationMap,
         PCTQualificationMap,
+        UnitCapacityMap,
+        UnitControlMap,
+        UnitFuelMap
       ],
     }).compile();
 
@@ -89,6 +99,7 @@ describe('MonitorPlanMap', () => {
     expect(result.facId).toEqual(facId);
     expect(result.orisCode).toEqual(orisCode);
     expect(result.name).toEqual(name);
+    expect(result.beginReportPeriodId).toEqual(beginReportPeriodId);
     expect(result.endReportPeriodId).toEqual(endReportPeriodId);
     expect(result.active).toEqual(active);
     expect(result.comments).toEqual(comments);

--- a/src/maps/monitor-plan.map.spec.ts
+++ b/src/maps/monitor-plan.map.spec.ts
@@ -86,7 +86,7 @@ describe('MonitorPlanMap', () => {
         PCTQualificationMap,
         UnitCapacityMap,
         UnitControlMap,
-        UnitFuelMap
+        UnitFuelMap,
       ],
     }).compile();
 

--- a/src/maps/monitor-plan.map.spec.ts
+++ b/src/maps/monitor-plan.map.spec.ts
@@ -34,7 +34,7 @@ const endReportPeriodId = 0;
 const beginReportPeriodId = 1;
 const active = false;
 const comments = [];
-const unitStackConfiguration = [];
+const unitStackConfigurations = [];
 const locations = [];
 const evalStatusCode = '';
 const userId = '';
@@ -105,7 +105,7 @@ describe('MonitorPlanMap', () => {
     expect(result.endReportPeriodId).toEqual(endReportPeriodId);
     expect(result.active).toEqual(active);
     expect(result.comments).toEqual(comments);
-    expect(result.unitStackConfiguration).toEqual(unitStackConfiguration);
+    expect(result.unitStackConfigurations).toEqual(unitStackConfigurations);
     expect(result.locations).toEqual(locations);
     expect(result.evalStatusCode).toEqual(evalStatusCode);
     expect(result.userId).toEqual(userId);

--- a/src/maps/monitor-plan.map.spec.ts
+++ b/src/maps/monitor-plan.map.spec.ts
@@ -24,6 +24,7 @@ import { MonitorPlanCommentMap } from './monitor-plan-comment.map';
 import { UnitCapacityMap } from './unit-capacity.map';
 import { UnitControlMap } from './unit-control.map';
 import { UnitFuelMap } from './unit-fuel.map';
+import { UnitStackConfigurationMap } from './unit-stack-configuration.map';
 
 const id = '';
 const facId = 0;
@@ -87,6 +88,7 @@ describe('MonitorPlanMap', () => {
         UnitCapacityMap,
         UnitControlMap,
         UnitFuelMap,
+        UnitStackConfigurationMap,
       ],
     }).compile();
 

--- a/src/maps/monitor-plan.map.ts
+++ b/src/maps/monitor-plan.map.ts
@@ -28,6 +28,7 @@ export class MonitorPlanMap extends BaseMap<MonitorPlan, MonitorPlanDTO> {
       facId: entity.facId,
       orisCode: entity.plant.orisCode,
       name: locations.map(l => l.name).join(', '),
+      beginReportPeriodId: entity.beginReportPeriodId,
       endReportPeriodId: entity.endReportPeriodId,
       active: entity.endReportPeriodId === null ? true : false,
       comments,

--- a/src/maps/monitor-plan.map.ts
+++ b/src/maps/monitor-plan.map.ts
@@ -5,12 +5,14 @@ import { MonitorPlan } from '../entities/monitor-plan.entity';
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
 import { MonitorLocationMap } from './monitor-location.map';
 import { MonitorPlanCommentMap } from './monitor-plan-comment.map';
+import { UnitStackConfigurationMap } from './unit-stack-configuration.map';
 
 @Injectable()
 export class MonitorPlanMap extends BaseMap<MonitorPlan, MonitorPlanDTO> {
   constructor(
     private locationMap: MonitorLocationMap,
     private commentMap: MonitorPlanCommentMap,
+    private unitStackConfigurationMap: UnitStackConfigurationMap,
   ) {
     super();
   }
@@ -22,6 +24,9 @@ export class MonitorPlanMap extends BaseMap<MonitorPlan, MonitorPlanDTO> {
     const comments = entity.comments
       ? await this.commentMap.many(entity.comments)
       : [];
+    const unitStackConfiguration = entity.unitStackConfiguration
+      ? await this.unitStackConfigurationMap.many(entity.unitStackConfiguration)
+      : [];
 
     return {
       id: entity.id,
@@ -32,7 +37,7 @@ export class MonitorPlanMap extends BaseMap<MonitorPlan, MonitorPlanDTO> {
       endReportPeriodId: entity.endReportPeriodId,
       active: entity.endReportPeriodId === null ? true : false,
       comments,
-      unitStackConfiguration: [],
+      unitStackConfiguration,
       locations,
       evalStatusCode: entity.evalStatusCode,
       userId: entity.userId,

--- a/src/maps/monitor-plan.map.ts
+++ b/src/maps/monitor-plan.map.ts
@@ -24,8 +24,10 @@ export class MonitorPlanMap extends BaseMap<MonitorPlan, MonitorPlanDTO> {
     const comments = entity.comments
       ? await this.commentMap.many(entity.comments)
       : [];
-    const unitStackConfiguration = entity.unitStackConfiguration
-      ? await this.unitStackConfigurationMap.many(entity.unitStackConfiguration)
+    const unitStackConfigurations = entity.unitStackConfigurations
+      ? await this.unitStackConfigurationMap.many(
+          entity.unitStackConfigurations,
+        )
       : [];
 
     return {
@@ -37,7 +39,7 @@ export class MonitorPlanMap extends BaseMap<MonitorPlan, MonitorPlanDTO> {
       endReportPeriodId: entity.endReportPeriodId,
       active: entity.endReportPeriodId === null ? true : false,
       comments,
-      unitStackConfiguration,
+      unitStackConfigurations,
       locations,
       evalStatusCode: entity.evalStatusCode,
       userId: entity.userId,

--- a/src/maps/monitor-plan.map.ts
+++ b/src/maps/monitor-plan.map.ts
@@ -12,7 +12,7 @@ export class MonitorPlanMap extends BaseMap<MonitorPlan, MonitorPlanDTO> {
   constructor(
     private locationMap: MonitorLocationMap,
     private commentMap: MonitorPlanCommentMap,
-    private unitStackConfigurationMap: UnitStackConfigurationMap,
+    private readonly unitStackConfigurationMap: UnitStackConfigurationMap,
   ) {
     super();
   }

--- a/src/monitor-location-workspace/monitor-location.service.spec.ts
+++ b/src/monitor-location-workspace/monitor-location.service.spec.ts
@@ -9,6 +9,22 @@ import { MonitorLocation } from '../entities/monitor-location.entity';
 import { UnitStackConfigurationWorkspaceService } from '../unit-stack-configuration-workspace/unit-stack-configuration.service';
 import { UnitStackConfigurationRepository } from '../unit-stack-configuration/unit-stack-configuration.repository';
 import { UnitStackConfigurationMap } from '../maps/unit-stack-configuration.map';
+import { UnitService } from '../unit/unit.service';
+import { StackPipeService } from '../stack-pipe/stack-pipe.service';
+import { ComponentWorkspaceService } from '../component-workspace/component.service';
+import { UnitCapacityWorkspaceService } from '../unit-capacity-workspace/unit-capacity.service';
+import { UnitControlWorkspaceService } from '../unit-control-workspace/unit-control.service';
+import { UnitFuelWorkspaceService } from '../unit-fuel-workspace/unit-fuel.service';
+import { MonitorQualificationWorkspaceService } from '../monitor-qualification-workspace/monitor-qualification.service';
+import { MonitorSystemWorkspaceService } from '../monitor-system-workspace/monitor-system.service';
+import { MonitorFormulaWorkspaceService } from '../monitor-formula-workspace/monitor-formula.service';
+import { MatsMethodWorkspaceService } from '../mats-method-workspace/mats-method.service';
+import { MonitorMethodWorkspaceService } from '../monitor-method-workspace/monitor-method.service';
+import { DuctWafWorkspaceService } from '../duct-waf-workspace/duct-waf.service';
+import { MonitorSpanWorkspaceService } from '../monitor-span-workspace/monitor-span.service';
+import { MonitorDefaultWorkspaceService } from '../monitor-default-workspace/monitor-default.service';
+import { MonitorLoadWorkspaceService } from '../monitor-load-workspace/monitor-load.service';
+import { MonitorAttributeWorkspaceService } from '../monitor-attribute-workspace/monitor-attribute.service';
 
 const locId = '6';
 
@@ -23,6 +39,7 @@ const mockMap = () => ({
 
 const mockUscService = () => ({
   getUnitStackRelationships: jest.fn().mockResolvedValue([]),
+  getUnitStackConfigsByLocationIds: jest.fn().mockResolvedValue([]),
 });
 
 describe('MonitorLocationWorkspaceService', () => {
@@ -35,12 +52,75 @@ describe('MonitorLocationWorkspaceService', () => {
         MonitorLocationWorkspaceService,
         MonitorLocationWorkspaceRepository,
         MonitorLocationMap,
+        UnitStackConfigurationMap,
         {
           provide: UnitStackConfigurationWorkspaceService,
           useFactory: mockUscService,
         },
-        UnitStackConfigurationRepository,
-        UnitStackConfigurationMap,
+        {
+          provide: UnitService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: StackPipeService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: ComponentWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: UnitCapacityWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: UnitControlWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: UnitFuelWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorQualificationWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorSystemWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorFormulaWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MatsMethodWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorMethodWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: DuctWafWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorSpanWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorDefaultWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorLoadWorkspaceService,
+          useFactory: () => ({}),
+        },
+        {
+          provide: MonitorAttributeWorkspaceService,
+          useFactory: () => ({}),
+        },
         {
           provide: MonitorLocationWorkspaceRepository,
           useFactory: mockRepository,

--- a/src/monitor-plan-workspace/monitor-plan.repository.ts
+++ b/src/monitor-plan-workspace/monitor-plan.repository.ts
@@ -6,9 +6,8 @@ import { MonitorPlan } from '../entities/workspace/monitor-plan.entity';
 export class MonitorPlanWorkspaceRepository extends Repository<MonitorPlan> {
   async getMonitorPlansByOrisCode(orisCode: number): Promise<MonitorPlan[]> {
     return this.createQueryBuilder('plan')
-      .innerJoinAndSelect('plan.plant', 'plant', 'plant.orisCode = :orisCode', {
-        orisCode,
-      })
+      .innerJoinAndSelect('plan.plant', 'plant')
+      .where('plant.orisCode = :orisCode', { orisCode })
       .getMany();
   }
 

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -158,21 +158,31 @@ export class MonitorPlanWorkspaceService {
     if (plans.length === 0) {
       return [];
     }
-
-    const locations = await this.locationRepository.getMonitorLocationsByFacId(
-      plans[0].facId,
-    );
-    plans.forEach(p => {
-      const matchedLocations: MonitorLocation[] = [];
-      locations.forEach(l => {
-        const planIds = l.plans.map(lp => lp.id);
-        if (planIds.includes(p.id)) {
-          matchedLocations.push(l);
-        }
-      });
-      p.locations = matchedLocations;
-    });
     const results = await this.map.many(plans);
+
+    for (const p of results) {
+      const monPlan = await this.exportMonitorPlan(p.id, false);
+      p.comments = monPlan.comments;
+      p.unitStackConfiguration = monPlan.unitStackConfiguration;
+      p.locations = monPlan.locations;
+
+      p.locations.forEach(l => {
+        delete l.attributes;
+        delete l.unitCapacities;
+        delete l.unitControls;
+        delete l.unitFuels;
+        delete l.methods;
+        delete l.matsMethods;
+        delete l.formulas;
+        delete l.defaults;
+        delete l.spans;
+        delete l.ductWafs;
+        delete l.loads;
+        delete l.components;
+        delete l.systems;
+        delete l.qualifications;
+      });
+    }
     results.sort((a, b) => {
       if (a.name < b.name) {
         return -1;
@@ -193,13 +203,7 @@ export class MonitorPlanWorkspaceService {
 
   async getMonitorPlan(monPlanId: string): Promise<MonitorPlanDTO> {
     const mp = await this.repository.getMonitorPlan(monPlanId);
-    const mpDTO = new MonitorPlanDTO();
-    mpDTO.id = mp.id;
-    mpDTO.updateDate = mp.updateDate;
-    mpDTO.userId = mp.userId;
-    mpDTO.evalStatusCode = mp.evalStatusCode;
-    mpDTO.facId = mp.facId;
-    return mpDTO;
+    return this.map.one(mp);
   }
 
   async updateDateAndUserId(monPlanId: string, userId: string): Promise<void> {
@@ -236,8 +240,25 @@ export class MonitorPlanWorkspaceService {
     await this.repository.resetToNeedsEvaluation(planId, userId);
   }
 
-  async exportMonitorPlan(planId: string): Promise<MonitorPlanDTO> {
+  async exportMonitorPlan(
+    planId: string,
+    getLocChildRecords: boolean = true,
+  ): Promise<MonitorPlanDTO> {
     const promises = [];
+    let UNIT_CAPACITIES,
+      UNIT_CONTROLS,
+      UNIT_FUEL,
+      ATTRIBUTES,
+      METHODS,
+      MATS_METHODS,
+      FORMULAS,
+      DEFAULTS,
+      SPANS,
+      DUCT_WAFS,
+      LOADS,
+      COMPONENTS,
+      SYSTEMS,
+      QUALIFICATIONS;
 
     const mp = await this.repository.getMonitorPlan(planId);
     mp.locations = await this.locationRepository.getMonitorLocationsByPlanId(
@@ -267,153 +288,157 @@ export class MonitorPlanWorkspaceService {
       ),
     );
 
-    const UNIT_CAPACITIES = UNIT_STACK_CONFIGS + 1;
-    promises.push(
-      this.unitCapacityRepository.getUnitCapacitiesByUnitIds(unitIds),
-    );
+    if (getLocChildRecords) {
+      UNIT_CAPACITIES = UNIT_STACK_CONFIGS + 1;
+      promises.push(
+        this.unitCapacityRepository.getUnitCapacitiesByUnitIds(unitIds),
+      );
 
-    const UNIT_CONTROLS = UNIT_CAPACITIES + 1;
-    promises.push(
-      this.unitControlRepository.find({ where: { unitId: In(unitIds) } }),
-    );
+      UNIT_CONTROLS = UNIT_CAPACITIES + 1;
+      promises.push(
+        this.unitControlRepository.find({ where: { unitId: In(unitIds) } }),
+      );
 
-    const UNIT_FUEL = UNIT_CONTROLS + 1;
-    promises.push(
-      this.unitFuelRepository.find({ where: { unitId: In(unitIds) } }),
-    );
+      UNIT_FUEL = UNIT_CONTROLS + 1;
+      promises.push(
+        this.unitFuelRepository.find({ where: { unitId: In(unitIds) } }),
+      );
 
-    const ATTRIBUTES = UNIT_FUEL + 1;
-    promises.push(
-      this.attributeRepository.find({ where: { locationId: In(locationIds) } }),
-    );
-
-    const METHODS = ATTRIBUTES + 1;
-    promises.push(
-      this.methodRepository.find({ where: { locationId: In(locationIds) } }),
-    );
-
-    const MATS_METHODS = METHODS + 1;
-    promises.push(
-      this.matsMethodRepository.find({
-        where: { locationId: In(locationIds) },
-      }),
-    );
-
-    const FORMULAS = MATS_METHODS + 1;
-    promises.push(
-      this.formulaRepository.find({ where: { locationId: In(locationIds) } }),
-    );
-
-    const DEFAULTS = FORMULAS + 1;
-    promises.push(
-      this.defaultRepository.find({ where: { locationId: In(locationIds) } }),
-    );
-
-    const SPANS = DEFAULTS + 1;
-    promises.push(
-      this.spanRepository.find({ where: { locationId: In(locationIds) } }),
-    );
-
-    const DUCT_WAFS = SPANS + 1;
-    promises.push(
-      this.ductWafRepository.find({ where: { locationId: In(locationIds) } }),
-    );
-
-    const LOADS = DUCT_WAFS + 1;
-    promises.push(
-      this.loadRepository.find({ where: { locationId: In(locationIds) } }),
-    );
-
-    const COMPONENTS = LOADS + 1;
-    promises.push(
-      new Promise(async (resolve, reject) => {
-        const components = await this.componentRepository.find({
+      ATTRIBUTES = UNIT_FUEL + 1;
+      promises.push(
+        this.attributeRepository.find({
           where: { locationId: In(locationIds) },
-        });
+        }),
+      );
 
-        const componentIds = components.map(i => i.id);
+      METHODS = ATTRIBUTES + 1;
+      promises.push(
+        this.methodRepository.find({ where: { locationId: In(locationIds) } }),
+      );
 
-        const analyzerRanges = this.analyzerRangeRepository.getAnalyzerRangesByCompIds(
-          componentIds,
-        );
-
-        const rangeResults = await Promise.all([analyzerRanges]);
-
-        components.forEach(async c => {
-          c.analyzerRanges = rangeResults[0].filter(
-            i => i.componentRecordId == c.id,
-          );
-        });
-
-        resolve(components);
-      }),
-    );
-
-    const SYSTEMS = COMPONENTS + 1;
-    promises.push(
-      new Promise(async (resolve, reject) => {
-        const systems = await this.systemRepository.find({
+      MATS_METHODS = METHODS + 1;
+      promises.push(
+        this.matsMethodRepository.find({
           where: { locationId: In(locationIds) },
-        });
+        }),
+      );
 
-        const systemIds = systems.map(i => i.id);
-        const s1 = this.systemFuelFlowRepository.getFuelFlowsBySystemIds(
-          systemIds,
-        );
-        const s2 = this.systemComponentRepository.getSystemComponentsBySystemIds(
-          systemIds,
-        );
+      FORMULAS = MATS_METHODS + 1;
+      promises.push(
+        this.formulaRepository.find({ where: { locationId: In(locationIds) } }),
+      );
 
-        const sysResults = await Promise.all([s1, s2]);
+      DEFAULTS = FORMULAS + 1;
+      promises.push(
+        this.defaultRepository.find({ where: { locationId: In(locationIds) } }),
+      );
 
-        systems.forEach(async s => {
-          s.fuelFlows = sysResults[0].filter(
-            i => i.monitoringSystemRecordId === s.id,
+      SPANS = DEFAULTS + 1;
+      promises.push(
+        this.spanRepository.find({ where: { locationId: In(locationIds) } }),
+      );
+
+      DUCT_WAFS = SPANS + 1;
+      promises.push(
+        this.ductWafRepository.find({ where: { locationId: In(locationIds) } }),
+      );
+
+      LOADS = DUCT_WAFS + 1;
+      promises.push(
+        this.loadRepository.find({ where: { locationId: In(locationIds) } }),
+      );
+
+      COMPONENTS = LOADS + 1;
+      promises.push(
+        new Promise(async (resolve, reject) => {
+          const components = await this.componentRepository.find({
+            where: { locationId: In(locationIds) },
+          });
+
+          const componentIds = components.map(i => i.id);
+
+          const analyzerRanges = this.analyzerRangeRepository.getAnalyzerRangesByCompIds(
+            componentIds,
           );
-          s.components = sysResults[1].filter(
-            i => i.monitoringSystemRecordId === s.id,
+
+          const rangeResults = await Promise.all([analyzerRanges]);
+
+          components.forEach(async c => {
+            c.analyzerRanges = rangeResults[0].filter(
+              i => i.componentRecordId == c.id,
+            );
+          });
+
+          resolve(components);
+        }),
+      );
+
+      SYSTEMS = COMPONENTS + 1;
+      promises.push(
+        new Promise(async (resolve, reject) => {
+          const systems = await this.systemRepository.find({
+            where: { locationId: In(locationIds) },
+          });
+
+          const systemIds = systems.map(i => i.id);
+          const s1 = this.systemFuelFlowRepository.getFuelFlowsBySystemIds(
+            systemIds,
           );
-        });
-
-        resolve(systems);
-      }),
-    );
-
-    const QUALIFICATIONS = SYSTEMS + 1;
-    promises.push(
-      new Promise(async (resolve, reject) => {
-        const quals = await this.qualificationRepository.find({
-          where: { locationId: In(locationIds) },
-        });
-
-        const qualIds = quals.map(i => i.id);
-        const q1 = this.leeQualificationRepository.find({
-          where: { qualificationId: In(qualIds) },
-        });
-        const q2 = this.lmeQualificationRepository.find({
-          where: { qualificationId: In(qualIds) },
-        });
-        const q3 = this.pctQualificationRepository.find({
-          where: { qualificationId: In(qualIds) },
-        });
-
-        const qualResults = await Promise.all([q1, q2, q3]);
-
-        quals.forEach(async q => {
-          q.leeQualifications = qualResults[0].filter(
-            i => i.qualificationId === q.id,
+          const s2 = this.systemComponentRepository.getSystemComponentsBySystemIds(
+            systemIds,
           );
-          q.lmeQualifications = qualResults[1].filter(
-            i => i.qualificationId === q.id,
-          );
-          q.pctQualifications = qualResults[2].filter(
-            i => i.qualificationId === q.id,
-          );
-        });
 
-        resolve(quals);
-      }),
-    );
+          const sysResults = await Promise.all([s1, s2]);
+
+          systems.forEach(async s => {
+            s.fuelFlows = sysResults[0].filter(
+              i => i.monitoringSystemRecordId === s.id,
+            );
+            s.components = sysResults[1].filter(
+              i => i.monitoringSystemRecordId === s.id,
+            );
+          });
+
+          resolve(systems);
+        }),
+      );
+
+      QUALIFICATIONS = SYSTEMS + 1;
+      promises.push(
+        new Promise(async (resolve, reject) => {
+          const quals = await this.qualificationRepository.find({
+            where: { locationId: In(locationIds) },
+          });
+
+          const qualIds = quals.map(i => i.id);
+          const q1 = this.leeQualificationRepository.find({
+            where: { qualificationId: In(qualIds) },
+          });
+          const q2 = this.lmeQualificationRepository.find({
+            where: { qualificationId: In(qualIds) },
+          });
+          const q3 = this.pctQualificationRepository.find({
+            where: { qualificationId: In(qualIds) },
+          });
+
+          const qualResults = await Promise.all([q1, q2, q3]);
+
+          quals.forEach(async q => {
+            q.leeQualifications = qualResults[0].filter(
+              i => i.qualificationId === q.id,
+            );
+            q.lmeQualifications = qualResults[1].filter(
+              i => i.qualificationId === q.id,
+            );
+            q.pctQualifications = qualResults[2].filter(
+              i => i.qualificationId === q.id,
+            );
+          });
+
+          resolve(quals);
+        }),
+      );
+    }
 
     const results = await Promise.all(promises);
 
@@ -424,35 +449,41 @@ export class MonitorPlanWorkspaceService {
 
       if (l.unit) {
         const unitId = l.unit.id;
-
-        l.unit.unitCapacities = results[UNIT_CAPACITIES].filter(
-          i => i.unitId === unitId,
-        );
-        l.unit.unitControls = results[UNIT_CONTROLS].filter(
-          i => i.unitId === unitId,
-        );
-        l.unit.unitFuels = results[UNIT_FUEL].filter(i => i.unitId === unitId);
+        if (getLocChildRecords) {
+          l.unit.unitCapacities = results[UNIT_CAPACITIES].filter(
+            i => i.unitId === unitId,
+          );
+          l.unit.unitControls = results[UNIT_CONTROLS].filter(
+            i => i.unitId === unitId,
+          );
+          l.unit.unitFuels = results[UNIT_FUEL].filter(
+            i => i.unitId === unitId,
+          );
+        }
       }
-
-      l.attributes = results[ATTRIBUTES].filter(
-        i => i.locationId === locationId,
-      );
-      l.methods = results[METHODS].filter(i => i.locationId === locationId);
-      l.matsMethods = results[MATS_METHODS].filter(
-        i => i.locationId === locationId,
-      );
-      l.formulas = results[FORMULAS].filter(i => i.locationId === locationId);
-      l.defaults = results[DEFAULTS].filter(i => i.locationId === locationId);
-      l.spans = results[SPANS].filter(i => i.locationId === locationId);
-      l.ductWafs = results[DUCT_WAFS].filter(i => i.locationId === locationId);
-      l.loads = results[LOADS].filter(i => i.locationId === locationId);
-      l.components = results[COMPONENTS].filter(
-        i => i.locationId === locationId,
-      );
-      l.systems = results[SYSTEMS].filter(i => i.locationId === locationId);
-      l.qualifications = results[QUALIFICATIONS].filter(
-        i => i.locationId === locationId,
-      );
+      if (getLocChildRecords) {
+        l.attributes = results[ATTRIBUTES].filter(
+          i => i.locationId === locationId,
+        );
+        l.methods = results[METHODS].filter(i => i.locationId === locationId);
+        l.matsMethods = results[MATS_METHODS].filter(
+          i => i.locationId === locationId,
+        );
+        l.formulas = results[FORMULAS].filter(i => i.locationId === locationId);
+        l.defaults = results[DEFAULTS].filter(i => i.locationId === locationId);
+        l.spans = results[SPANS].filter(i => i.locationId === locationId);
+        l.ductWafs = results[DUCT_WAFS].filter(
+          i => i.locationId === locationId,
+        );
+        l.loads = results[LOADS].filter(i => i.locationId === locationId);
+        l.components = results[COMPONENTS].filter(
+          i => i.locationId === locationId,
+        );
+        l.systems = results[SYSTEMS].filter(i => i.locationId === locationId);
+        l.qualifications = results[QUALIFICATIONS].filter(
+          i => i.locationId === locationId,
+        );
+      }
     });
 
     const uscDTO = await this.uscMap.many(results[UNIT_STACK_CONFIGS]);

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -162,6 +162,7 @@ export class MonitorPlanWorkspaceService {
 
     for (const p of results) {
       const monPlan = await this.exportMonitorPlan(p.id, false);
+
       p.comments = monPlan.comments;
       p.unitStackConfiguration = monPlan.unitStackConfiguration;
       p.locations = monPlan.locations;

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -5,7 +5,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
 import { MPEvaluationReportDTO } from '../dtos/mp-evaluation-report.dto';
 import { MonitorPlanMap } from '../maps/monitor-plan.map';
-import { MonitorLocation } from '../entities/workspace/monitor-location.entity';
 import { CountyCodeService } from '../county-code/county-code.service';
 import { MonitorPlanReportResultService } from '../monitor-plan-report-result/monitor-plan-report-result.service';
 import { MonitorPlanWorkspaceRepository } from './monitor-plan.repository';

--- a/src/monitor-plan/monitor-plan.service.ts
+++ b/src/monitor-plan/monitor-plan.service.ts
@@ -4,7 +4,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { MonitorPlanMap } from '../maps/monitor-plan.map';
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
-import { MonitorLocation } from '../entities/monitor-location.entity';
 import { SystemFuelFlow } from '../entities/system-fuel-flow.entity';
 
 import { MonitorPlanRepository } from './monitor-plan.repository';

--- a/src/system-component-workspace/system-component.controller.spec.ts
+++ b/src/system-component-workspace/system-component.controller.spec.ts
@@ -37,8 +37,8 @@ describe('SystemComponentWorkspaceController', () => {
 
   describe('getComponents', () => {
     it('should return array of system components', async () => {
-      jest.spyOn(service, 'getComponents').mockResolvedValue(data);
-      expect(await controller.getComponents(locId, sysId)).toBe(data);
+      jest.spyOn(service, 'getSystemComponents').mockResolvedValue(data);
+      expect(await controller.getSystemComponents(locId, sysId)).toBe(data);
     });
   });
 });

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.spec.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.spec.ts
@@ -77,7 +77,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         location.stackPipeId = 'TEST';
 
         const plan = new UpdateMonitorPlanDTO();
-        plan.unitStackConfiguration = [unitStackConfig];
+        plan.unitStackConfigurations = [unitStackConfig];
         plan.locations = [location];
 
         const result = service.runUnitStackChecks(plan);
@@ -98,7 +98,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         location2.stackPipeId = 'TEST';
 
         const plan = new UpdateMonitorPlanDTO();
-        plan.unitStackConfiguration = [unitStackConfig];
+        plan.unitStackConfigurations = [unitStackConfig];
         plan.locations = [location, location2];
 
         const result = service.runUnitStackChecks(plan);
@@ -122,7 +122,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         location2.stackPipeId = 'TEST';
 
         const plan = new UpdateMonitorPlanDTO();
-        plan.unitStackConfiguration = [unitStackConfig];
+        plan.unitStackConfigurations = [unitStackConfig];
         plan.locations = [location, location2];
 
         const result = service.runUnitStackChecks(plan);
@@ -146,7 +146,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         location.stackPipeId = 'TEST';
 
         const plan = new UpdateMonitorPlanDTO();
-        plan.unitStackConfiguration = [unitStackConfig, unitStackConfig2];
+        plan.unitStackConfigurations = [unitStackConfig, unitStackConfig2];
         plan.locations = [location];
 
         const result = service.runUnitStackChecks(plan);
@@ -171,7 +171,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         location.stackPipeId = 'TEST';
 
         const plan = new UpdateMonitorPlanDTO();
-        plan.unitStackConfiguration = [unitStackConfig, unitStackConfig2];
+        plan.unitStackConfigurations = [unitStackConfig, unitStackConfig2];
         plan.locations = [location];
 
         const result = service.runUnitStackChecks(plan);
@@ -186,7 +186,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
   describe('importUnitStack', () => {
     it('Should create new record given an undefined one', async () => {
       const plan = new UpdateMonitorPlanDTO();
-      plan.unitStackConfiguration = [new UnitStackConfigurationBaseDTO()];
+      plan.unitStackConfigurations = [new UnitStackConfigurationBaseDTO()];
       await service.importUnitStack(plan, 1, '');
       expect(repo.create).toHaveBeenCalled();
     });

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -38,7 +38,7 @@ export class UnitStackConfigurationWorkspaceService {
       }
     }
 
-    for (const unitStackConfig of monitorPlan.unitStackConfiguration) {
+    for (const unitStackConfig of monitorPlan.unitStackConfigurations) {
       if (!unitStackIds.has(unitStackConfig.stackPipeId)) {
         errorList.push(
           `[IMPORT8-CRIT1-A] Each Stack/Pipe and Unit in a unit stack configuration record must be linked to unit and stack/pipe records that are also present in the file. StackPipeID ${unitStackConfig.stackPipeId} was not associated with a Stack/Pipe record in the file.`,
@@ -83,7 +83,7 @@ export class UnitStackConfigurationWorkspaceService {
   ) {
     return new Promise(async resolve => {
       const promises = [];
-      for (const unitStackConfig of plan.unitStackConfiguration) {
+      for (const unitStackConfig of plan.unitStackConfigurations) {
         promises.push(
           new Promise(async innerResolve => {
             const stackPipe = await this.stackPipeService.getStackByNameAndFacId(

--- a/src/unit-stack-configuration/unit-stack-configuration.repository.ts
+++ b/src/unit-stack-configuration/unit-stack-configuration.repository.ts
@@ -5,4 +5,15 @@ import { UnitStackConfiguration } from '../entities/unit-stack-configuration.ent
 @EntityRepository(UnitStackConfiguration)
 export class UnitStackConfigurationRepository extends Repository<
   UnitStackConfiguration
-> {}
+> {
+  async getUnitStackConfigsByLocationIds(locationIds: string[]) {
+    return this.createQueryBuilder('usc')
+      .innerJoinAndSelect('usc.unit', 'u')
+      .innerJoinAndSelect('usc.stackPipe', 'sp')
+      .innerJoin('u.location', 'mlu')
+      .innerJoin('sp.location', 'mlsp')
+      .where('mlu.id IN (:...locationIds)', { locationIds })
+      .andWhere('mlsp.id IN (:...locationIds)', { locationIds })
+      .getMany();
+  }
+}

--- a/src/unit/unit.service.spec.ts
+++ b/src/unit/unit.service.spec.ts
@@ -41,7 +41,7 @@ describe('Unit Import Tests', () => {
       expect(result).toEqual([]);
     });
 
-    it('Should error given a undefined entry for facilityId and unitId in unitStackConfiguration', async () => {
+    it('Should error given a undefined entry for facilityId and unitId in unitStackConfigurations', async () => {
       repository.findOne = jest.fn().mockResolvedValue(undefined);
 
       const location = new UpdateMonitorLocationDTO();


### PR DESCRIPTION
## [Feature/3660: Add "beginReportPeriodId" to Configuration endpoints, "stackPipeRecordId" to locations data and also returns comments and unitStackConfiguration data ](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3660)