### PR TITLE
feature/4025-Configure-Refresh

### DIFF
--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -46,7 +46,7 @@ export class MonitorPlanWorkspaceController {
   }
 
   // TEMP: unconventional route path to avoid messing with URL's before demo
-  @Get(':planId/refresh')
+  @Get(':planId')
   @ApiOkResponse({
     type: MonitorPlanDTO,
     description: 'Retrieves information needed to refresh a monitor plan',

--- a/src/monitor-plan-workspace/monitor-plan.repository.spec.ts
+++ b/src/monitor-plan-workspace/monitor-plan.repository.spec.ts
@@ -4,7 +4,6 @@ import { SelectQueryBuilder } from 'typeorm';
 
 import { MonitorPlanWorkspaceRepository } from './monitor-plan.repository';
 import { MonitorPlan } from '../entities/monitor-plan.entity';
-import { LastUpdatedConfigBaseDTO } from 'src/dtos/last-updated-config-base.dto';
 
 const mp = new MonitorPlan();
 const mpArray = [mp];

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -168,7 +168,7 @@ export class MonitorPlanWorkspaceService {
         false,
         false,
         false,
-        false,
+        true,
       );
       p.name = monPlan.name;
       p.locations = monPlan.locations;

--- a/src/monitor-plan/monitor-plan.controller.spec.ts
+++ b/src/monitor-plan/monitor-plan.controller.spec.ts
@@ -40,6 +40,13 @@ describe('MonitorPlanController', () => {
     });
   });
 
+  describe('getMonitorPlan', () => {
+    it('should return a monitor plan given a planId', async () => {
+      jest.spyOn(service, 'getTopLevelMonitorPlan').mockResolvedValue(data[0]);
+      expect(await controller.getMonitorPlan('')).toBe(data[0]);
+    });
+  });
+
   describe('configuration/last-updated', () => {
     it('should return array of monitor plan configurations and a most recent update time', async () => {
       const dto = new LastUpdatedConfigDTO();

--- a/src/monitor-plan/monitor-plan.controller.ts
+++ b/src/monitor-plan/monitor-plan.controller.ts
@@ -16,8 +16,17 @@ export class MonitorPlanController {
     type: MonitorPlanDTO,
     description: 'Retrieves official Monitor Plan record',
   })
-  getMonitorPlan(@Query('planId') planId: string): Promise<MonitorPlanDTO> {
+  exportMonitorPlan(@Query('planId') planId: string): Promise<MonitorPlanDTO> {
     return this.service.getMonitorPlan(planId);
+  }
+
+  @Get(':planId')
+  @ApiOkResponse({
+    type: MonitorPlanDTO,
+    description: 'Retrieves information needed to refresh a monitor plan',
+  })
+  getMonitorPlan(@Param('planId') planId: string): Promise<MonitorPlanDTO> {
+    return this.service.getTopLevelMonitorPlan(planId);
   }
 
   @Get(':orisCode/configurations')

--- a/src/monitor-plan/monitor-plan.service.ts
+++ b/src/monitor-plan/monitor-plan.service.ts
@@ -185,6 +185,11 @@ export class MonitorPlanService {
     return dto;
   }
 
+  async getTopLevelMonitorPlan(monPlanId: string): Promise<MonitorPlanDTO> {
+    const mp = await this.repository.getMonitorPlan(monPlanId);
+    return this.map.one(mp);
+  }
+
   async getMonitorPlan(
     planId: string,
     getLocChildRecords: boolean = true,


### PR DESCRIPTION
Configured back end, endpoints to have consistent naming standards. Renamed /refresh endpoint.