### PR TITLE
Feature/4891 mp checks

### DIFF
--- a/src/dtos/duct-waf.dto.ts
+++ b/src/dtos/duct-waf.dto.ts
@@ -8,6 +8,7 @@ import {
   IsNotEmpty,
   IsNumber,
   IsOptional,
+  IsPositive,
   IsString,
   ValidateIf,
   ValidationArguments,
@@ -15,6 +16,10 @@ import {
 import { IsInRange, IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { IsAtMostDigits } from '../import-checks/pipes/is-at-most-digits.pipe';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR } from '../utilities/constants';
+
+const KEY = 'Rectangular Duct Waf';
 
 export class DuctWafBaseDTO {
   @ApiProperty({
@@ -25,7 +30,14 @@ export class DuctWafBaseDTO {
   @IsOptional()
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be a valid ISO date format yyyy-mm-dd`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be a valid ISO date format [dateFormat]`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+          dateFormat: DATE_FORMAT,
+        }
+      );
     },
   })
   wafDeterminationDate: Date;
@@ -38,7 +50,14 @@ export class DuctWafBaseDTO {
   @IsNotEmpty()
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be a valid ISO date format yyyy-mm-dd`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be a valid ISO date format [dateFormat]`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+          dateFormat: DATE_FORMAT,
+        }
+      );
     },
   })
   wafBeginDate: Date;
@@ -50,9 +69,15 @@ export class DuctWafBaseDTO {
   })
   @IsNotEmpty()
   @IsInt()
-  @IsInRange(0, 23, {
+  @IsInRange(MIN_HOUR, MAX_HOUR, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be within the range of 0 and 23`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be within the range of 0 and 23`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   wafBeginHour: number;
@@ -67,7 +92,13 @@ export class DuctWafBaseDTO {
     'SELECT waf_method_cd as "value" FROM camdecmpsmd.waf_method_code',
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [RECTDUCTWAF-FATAL-B] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} is invalid`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is invalid`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
@@ -79,18 +110,35 @@ export class DuctWafBaseDTO {
     example: propertyMetadata.ductWafDTOWafValue.example,
     name: propertyMetadata.ductWafDTOWafValue.fieldLabels.value,
   })
-  @IsNotEmpty()
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('DEFAULT-80-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsNumber(
     { maxDecimalPlaces: 4 },
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} is allowed only 4 decimal place`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is allowed only 4 decimal place`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
-  @IsInRange(-99.9999, 99.9999, {
+  @IsInRange(0, 1, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be within the range of -99.9999 and 99.9999`;
+      return CheckCatalogService.formatResultMessage('DEFAULT-80-D', {
+        fieldname: args.property,
+        value: args.value,
+        key: KEY,
+      });
     },
   })
   wafValue: number;
@@ -104,7 +152,13 @@ export class DuctWafBaseDTO {
   @IsInt()
   @IsAtMostDigits(2, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be 2 digits or less`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be 2 digits or less`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   numberOfTestRuns: number;
@@ -120,7 +174,13 @@ export class DuctWafBaseDTO {
   @IsInt()
   @IsAtMostDigits(2, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be 2 digits or less`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be 2 digits or less`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   numberOfTraversePointsWaf: number;
@@ -134,7 +194,13 @@ export class DuctWafBaseDTO {
   @IsInt()
   @IsAtMostDigits(2, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be 2 digits or less`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be 2 digits or less`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   numberOfTestPorts: number;
@@ -150,7 +216,13 @@ export class DuctWafBaseDTO {
   @IsInt()
   @IsAtMostDigits(2, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be 2 digits or less`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be 2 digits or less`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   numberOfTraversePointsRef: number;
@@ -160,18 +232,35 @@ export class DuctWafBaseDTO {
     example: propertyMetadata.ductWafDTODuctWidth.example,
     name: propertyMetadata.ductWafDTODuctWidth.fieldLabels.value,
   })
-  @IsOptional()
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('DEFAULT-78-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsNumber(
     { maxDecimalPlaces: 1 },
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} is allowed only 1 decimal place`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is allowed only 1 decimal place`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
-  @IsInRange(-9999.9, 9999.9, {
+  @IsPositive({
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be within the range of -9999.9 and 9999.9`;
+      return CheckCatalogService.formatResultMessage('DEFAULT-78-B', {
+        fieldname: args.property,
+        value: args.value,
+        key: KEY,
+      });
     },
   })
   ductWidth: number;
@@ -181,18 +270,35 @@ export class DuctWafBaseDTO {
     example: propertyMetadata.ductWafDTODuctDepth.example,
     name: propertyMetadata.ductWafDTODuctDepth.fieldLabels.value,
   })
-  @IsOptional()
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('DEFAULT-79-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsNumber(
     { maxDecimalPlaces: 1 },
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} is allowed only 1 decimal place`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is allowed only 1 decimal place`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
-  @IsInRange(-9999.9, 9999.9, {
+  @IsPositive({
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be within the range of -9999.9 and 9999.9`;
+      return CheckCatalogService.formatResultMessage('DEFAULT-79-B', {
+        fieldname: args.property,
+        value: args.value,
+        key: KEY,
+      });
     },
   })
   ductDepth: number;
@@ -206,7 +312,14 @@ export class DuctWafBaseDTO {
   @ValidateIf(o => o.wafEndHour !== null)
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be a valid ISO date format yyyy-mm-dd`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be a valid ISO date format [dateFormat]`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+          dateFormat: DATE_FORMAT,
+        }
+      );
     },
   })
   wafEndDate: Date;
@@ -219,9 +332,15 @@ export class DuctWafBaseDTO {
   @IsOptional()
   @ValidateIf(o => o.wafEndDate !== null)
   @IsInt()
-  @IsInRange(0, 23, {
+  @IsInRange(MIN_HOUR, MAX_HOUR, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [RECTDUCTWAF-FATAL-A] The value for ${args.value} in the Rectangular Duct Waf record ${args.property} must be within the range of 0 and 23`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be within the range of 0 and 23`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   wafEndHour: number;

--- a/src/dtos/monitor-default.dto.ts
+++ b/src/dtos/monitor-default.dto.ts
@@ -16,6 +16,10 @@ import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 
 import { IsInRange, IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR } from '../utilities/constants';
+
+const KEY = 'Monitor Default';
 
 export class MonitorDefaultBaseDTO {
   @ApiProperty({
@@ -28,7 +32,13 @@ export class MonitorDefaultBaseDTO {
     'SELECT distinct parameter_code as "value" FROM camdecmpsmd.vw_defaults_master_data_relationships',
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [DEFAULT-FATAL-B] The value : ${args.value} for ${args.property} is invalid`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is invalid`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
@@ -45,13 +55,25 @@ export class MonitorDefaultBaseDTO {
     { maxDecimalPlaces: 4 },
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [DEFAULT-FATAL-A] The value : ${args.value} for ${args.property} is allowed only four decimal place`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is allowed only four decimal place`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
   @IsInRange(-99999999999.9999, 99999999999.9999, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [DEFAULT-FATAL-A] The value : ${args.value} for ${args.property} must be within the range of -99999999999.9999 and 99999999999.9999`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be within the range of -99999999999.9999 and 99999999999.9999`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   defaultValue: number;
@@ -70,7 +92,13 @@ export class MonitorDefaultBaseDTO {
     'SELECT distinct unit_of_measure_code as "value" FROM camdecmpsmd.vw_defaults_master_data_relationships',
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [DEFAULT-FATAL-B] The value : ${args.value} for ${args.property} is invalid`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is invalid`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
@@ -88,7 +116,13 @@ export class MonitorDefaultBaseDTO {
     'SELECT distinct purpose_code as "value" FROM camdecmpsmd.vw_defaults_master_data_relationships',
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [DEFAULT-FATAL-B] The value : ${args.value} for ${args.property} is invalid`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is invalid`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
@@ -100,12 +134,25 @@ export class MonitorDefaultBaseDTO {
     example: propertyMetadata.monitorDefaultDTOFuelCode.example,
     name: propertyMetadata.monitorDefaultDTOFuelCode.fieldLabels.value,
   })
-  @IsOptional()
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('DEFAULT-53-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsInDbValues(
     'SELECT distinct fuel_code as "value" FROM camdecmpsmd.vw_defaults_master_data_relationships',
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [DEFAULT-FATAL-B] The value : ${args.value} for ${args.property} is invalid`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is invalid`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
@@ -125,7 +172,13 @@ export class MonitorDefaultBaseDTO {
     'SELECT distinct operating_condition_code as "value" FROM camdecmpsmd.vw_defaults_master_data_relationships',
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [DEFAULT-FATAL-B] The value : ${args.value} for ${args.property} is invalid`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is invalid`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
@@ -138,12 +191,25 @@ export class MonitorDefaultBaseDTO {
     example: propertyMetadata.monitorDefaultDTODefaultSourceCode.example,
     name: propertyMetadata.monitorDefaultDTODefaultSourceCode.fieldLabels.value,
   })
-  @IsOptional()
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('DEFAULT-52-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsInDbValues(
     'SELECT distinct source_code as "value" FROM camdecmpsmd.vw_defaults_master_data_relationships',
     {
       message: (args: ValidationArguments) => {
-        return `${args.property} [DEFAULT-FATAL-B] The value : ${args.value} for ${args.property} is invalid`;
+        return CheckCatalogService.formatMessage(
+          `The value for [fieldName] for [key] is invalid`, 
+          {
+            fieldname: args.property,
+            key: KEY,
+          }
+        );
       },
     },
   )
@@ -158,7 +224,13 @@ export class MonitorDefaultBaseDTO {
   @IsOptional()
   @MaxLength(10, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [DEFAULT-FATAL-A] The value : ${args.value} for ${args.property} must not exceed 10 characters`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must not exceed 10 characters`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   @ValidateIf(o => o.groupId !== null)
@@ -173,7 +245,14 @@ export class MonitorDefaultBaseDTO {
   @IsNotEmpty()
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `${args.property} [DEFAULT-FATAL-A] The value : ${args.value} for ${args.property} must be a valid ISO date format yyyy-mm-dd`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be a valid ISO date format [dateFormat]`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+          dateFormat: DATE_FORMAT,
+        }
+      );
     },
   })
   beginDate: Date;
@@ -185,9 +264,15 @@ export class MonitorDefaultBaseDTO {
   })
   @IsNotEmpty()
   @IsInt()
-  @IsInRange(0, 23, {
+  @IsInRange(MIN_HOUR, MAX_HOUR, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [DEFAULT-FATAL-A] The value : ${args.value} for ${args.property} must be within the range of 0 and 23`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be within the range of 0 and 23`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   beginHour: number;
@@ -200,7 +285,14 @@ export class MonitorDefaultBaseDTO {
   @IsOptional()
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `${args.property} [DEFAULT-FATAL-A] The value : ${args.value} for ${args.property} must be a valid ISO date format yyyy-mm-dd`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be a valid ISO date format [dateFormat]`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+          dateFormat: DATE_FORMAT,
+        }
+      );
     },
   })
   @ValidateIf(o => o.endHour !== null)
@@ -213,9 +305,15 @@ export class MonitorDefaultBaseDTO {
   })
   @IsOptional()
   @IsInt()
-  @IsInRange(0, 23, {
+  @IsInRange(MIN_HOUR, MAX_HOUR, {
     message: (args: ValidationArguments) => {
-      return `${args.property} [DEFAULT-FATAL-A] The value : ${args.value} for ${args.property} must be within the range of 0 and 23`;
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldName] for [key] must be within the range of 0 and 23`, 
+        {
+          fieldname: args.property,
+          key: KEY,
+        }
+      );
     },
   })
   @ValidateIf(o => o.endDate !== null)


### PR DESCRIPTION
The scope of this ticket is to address the following Checks:

[ECMPS Monitoring Plan Check Specifications](https://ecmps.camdsupport.com/documents/ECMPS%20Monitoring%20Plan%20Check%20Specifications%202022%20Q1.pdf)

 DEFAULT-52 - Default Source Code Valid (Results A)
 DEFAULT-53 - Default Fuel Code Valid (Results A)
 DEFAULT-78 - Rectangular Duct WAF Duct Width at Test Location Valid (Results A, B)
 DEFAULT-79 - Rectangular Duct WAF Duct Depth at Test Location Valid (Results A, B)
 DEFAULT-80 - Rectangular Duct WAF Value Valid (Result A, D)