### PR TITLE
update truthy check to null check

### DIFF
--- a/src/mats-method-workspace/mats-method-checks.service.ts
+++ b/src/mats-method-workspace/mats-method-checks.service.ts
@@ -52,7 +52,7 @@ export class MatsMethodChecksService {
   ): string {
     let error = null;
 
-    if (!matsMethod.endHour && matsMethod.endDate) {
+    if (matsMethod.endHour === null && matsMethod.endDate) {
       error = this.getMessage('MATSMTH-4-C');
       return error;
     }


### PR DESCRIPTION
When a user wishes to create MATS Method data with an End Time of 0, then the system throws a validation that shouldn't be displayed