### PR TITLE
5942 - Skip Import Checks for Inactive MP Record Types

### DIFF
--- a/src/monitor-formula-workspace/monitor-formula.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula.service.ts
@@ -138,7 +138,7 @@ export class MonitorFormulaWorkspaceService {
         formulaId: formula.formulaId,
       });
 
-      if (formulaRecord) {
+      if (formulaRecord && ! formulaRecord.endDate) {
         if (formulaRecord.parameterCode !== formula.parameterCode) {
           errorList.push(
             `[IMPORT9-CRIT1-A] The ParameterCode for Formula ID ${formulaRecord.formulaId} in the database is not equal to the ParameterCode ${formula.formulaId} in the incoming record`,

--- a/src/monitor-qualification-workspace/monitor-qualification.service.ts
+++ b/src/monitor-qualification-workspace/monitor-qualification.service.ts
@@ -38,6 +38,9 @@ export class MonitorQualificationWorkspaceService {
     const errorList: string[] = [];
 
     for (const qual of qualifications) {
+
+      if(qual.endDate) continue; // Don't perform checks on Inactive MonitorQualification Record
+      
       if (qual.qualificationTypeCode !== 'LMEA') {
         qual.monitoringQualificationLMEData.forEach((lmeQual, idx) => {
           if (lmeQual.so2Tons !== null) {


### PR DESCRIPTION
Updated to skip import checks for 2 more record types in Monitoring Plan when they are inactive (have an enddate)