### PR TITLE
fix:spanscaleCode check for all componentTypeCode except FLOW

### DIFF
--- a/src/monitor-span-workspace/monitor-span-checks.service.ts
+++ b/src/monitor-span-workspace/monitor-span-checks.service.ts
@@ -318,7 +318,7 @@ export class MonitorSpanChecksService {
         beginHour,
         endDate,
         endHour,
-        !isFlowType ? undefined : monitorSpan.spanScaleCode,
+        isFlowType ? undefined : monitorSpan.spanScaleCode,
       );
 
       if (record) {


### PR DESCRIPTION
## Ticket
[SPAN-55-A screen check prevents adding new H and L span records for applicable components](https://github.com/US-EPA-CAMD/easey-ui/issues/5999)

## Changes

- In record finding function check `spanscaleCode` checks for all `componentType` Code except `FLOW`

[ECMPS Monitoring Plan Check Specifications](https://ecmps.camdsupport.com/documents/ECMPS%20Monitoring%20Plan%20Check%20Specifications%202022%20Q1.pdf) (page number 416)