### PR TITLE
Fix/6029 correct duct waf range

### DIFF
--- a/src/analyzer-range-workspace/analyzer-range.service.ts
+++ b/src/analyzer-range-workspace/analyzer-range.service.ts
@@ -140,14 +140,14 @@ export class AnalyzerRangeWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/component-workspace/component-checks.service.ts
+++ b/src/component-workspace/component-checks.service.ts
@@ -69,7 +69,7 @@ export class ComponentCheckService {
   }
 
   private async component13Check(
-    component: UpdateComponentBaseDTO ,
+    component: UpdateComponentBaseDTO,
     errorLocation: string = '',
   ): Promise<string> {
     let error = null;

--- a/src/component-workspace/component.controller.spec.ts
+++ b/src/component-workspace/component.controller.spec.ts
@@ -30,9 +30,9 @@ describe('ComponentWorkspaceController', () => {
       imports: [HttpModule, LoggerModule],
       controllers: [ComponentWorkspaceController],
       providers: [
-        ComponentWorkspaceService, 
-        ConfigService, 
-        ComponentCheckService, 
+        ComponentWorkspaceService,
+        ConfigService,
+        ComponentCheckService,
         SystemComponentMasterDataRelationshipRepository,
         UsedIdentifierRepository,
         ComponentWorkspaceRepository,
@@ -57,20 +57,22 @@ describe('ComponentWorkspaceController', () => {
     });
   });
 
-  describe('createComponent', ()=>{
-    it('should create a new component', async ()=>{
+  describe('createComponent', () => {
+    it('should create a new component', async () => {
       const mockedReturnDto = new ComponentDTO();
       const mockedPayloadDto = new UpdateComponentBaseDTO();
       const user: CurrentUser = {
-        userId: "",
-        sessionId: "",
-        expiration: "",
-        clientIp: "",
+        userId: '',
+        sessionId: '',
+        expiration: '',
+        clientIp: '',
         facilities: [],
         roles: [],
-    }
+      };
       jest.spyOn(service, 'createComponent').mockResolvedValue(mockedReturnDto);
-      expect(await controller.createComponent("", mockedPayloadDto, user)).toBe(mockedReturnDto)
-    })
-  })
+      expect(await controller.createComponent('', mockedPayloadDto, user)).toBe(
+        mockedReturnDto,
+      );
+    });
+  });
 });

--- a/src/component-workspace/component.service.ts
+++ b/src/component-workspace/component.service.ts
@@ -25,7 +25,7 @@ export class ComponentWorkspaceService {
 
     @Inject(forwardRef(() => MonitorPlanWorkspaceService))
     private readonly mpService: MonitorPlanWorkspaceService,
-  ) { }
+  ) {}
 
   async runComponentChecks(
     components: UpdateComponentBaseDTO[],
@@ -116,7 +116,6 @@ export class ComponentWorkspaceService {
     locationId: string,
     userId: string,
   ) {
-
     return new Promise(resolve => {
       (async () => {
         const innerPromises = [];
@@ -151,7 +150,6 @@ export class ComponentWorkspaceService {
                     component,
                     userId,
                   );
-
                 } else {
                   await this.createComponent(locationId, component, userId);
                   compRecord = await this.repository.getComponentByLocIdAndCompId(
@@ -167,15 +165,14 @@ export class ComponentWorkspaceService {
                   userId,
                 );
 
-
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
         await Promise.all(innerPromises);
         resolve(true);
-      })()
+      })();
     });
   }
 
@@ -185,7 +182,6 @@ export class ComponentWorkspaceService {
     payload: UpdateComponentBaseDTO,
     userId: string,
   ): Promise<ComponentDTO> {
-
     componentRecord.modelVersion = payload.modelVersion;
     componentRecord.serialNumber = payload.serialNumber;
     componentRecord.hgConverterIndicator = payload.hgConverterIndicator;

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -11,15 +11,17 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
 
   constructor(private readonly configService: ConfigService) {
     const host = configService.get<string>('database.host');
-    this.tlsOptions.rejectUnauthorized = (host !== 'localhost');
-    this.tlsOptions.ca = (host !== 'localhost')
-      ? readFileSync("./us-gov-west-1-bundle.pem").toString()
-      : null;
+    this.tlsOptions.rejectUnauthorized = host !== 'localhost';
+    this.tlsOptions.ca =
+      host !== 'localhost'
+        ? readFileSync('./us-gov-west-1-bundle.pem').toString()
+        : null;
     console.log('TLS/SSL Config:', {
       ...this.tlsOptions,
-      ca: (this.tlsOptions.ca !== null)
-        ? `${this.tlsOptions.ca.slice(0, 30)}...(truncated for display only)`
-        : null
+      ca:
+        this.tlsOptions.ca !== null
+          ? `${this.tlsOptions.ca.slice(0, 30)}...(truncated for display only)`
+          : null,
     });
   }
 

--- a/src/dtos/duct-waf.dto.ts
+++ b/src/dtos/duct-waf.dto.ts
@@ -19,11 +19,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import {
-  DATE_FORMAT,
-  MAX_HOUR,
-  MIN_HOUR,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR } from '../utilities/constants';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 
 const KEY = 'Rectangular Duct Waf';
@@ -174,7 +170,7 @@ export class DuctWafBaseDTO {
   )
   @IsInRange(
     0,
-    99.9999,
+    1,
     {
       message: (args: ValidationArguments) => {
         return CheckCatalogService.formatResultMessage('DEFAULT-80-D', {

--- a/src/dtos/system-component.dto.ts
+++ b/src/dtos/system-component.dto.ts
@@ -14,7 +14,12 @@ import {
 } from 'class-validator';
 import { ComponentBaseDTO } from './component.dto';
 import { IsInRange } from '@us-epa-camd/easey-common/pipes/is-in-range.pipe';
-import {IsIsoFormat, IsValidDate, MatchesRegEx, IsValidCode} from '@us-epa-camd/easey-common/pipes';
+import {
+  IsIsoFormat,
+  IsValidDate,
+  MatchesRegEx,
+  IsValidCode,
+} from '@us-epa-camd/easey-common/pipes';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 import {
@@ -56,9 +61,11 @@ export class SystemComponentBaseDTO {
   componentId: string;
 
   @ApiProperty({
-    description: propertyMetadata.systemComponentDTOComponentTypeCode.description,
+    description:
+      propertyMetadata.systemComponentDTOComponentTypeCode.description,
     example: propertyMetadata.systemComponentDTOComponentTypeCode.example,
-    name: propertyMetadata.systemComponentDTOComponentTypeCode.fieldLabels.value,
+    name:
+      propertyMetadata.systemComponentDTOComponentTypeCode.fieldLabels.value,
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
@@ -105,8 +112,10 @@ export class SystemComponentBaseDTO {
 
   @ApiProperty({
     description:
-      propertyMetadata.systemComponentDTOSampleAcquisitionMethodCode.description,
-    example: propertyMetadata.systemComponentDTOSampleAcquisitionMethodCode.example,
+      propertyMetadata.systemComponentDTOSampleAcquisitionMethodCode
+        .description,
+    example:
+      propertyMetadata.systemComponentDTOSampleAcquisitionMethodCode.example,
     name:
       propertyMetadata.systemComponentDTOSampleAcquisitionMethodCode.fieldLabels
         .value,
@@ -190,9 +199,11 @@ export class SystemComponentBaseDTO {
   serialNumber: string;
 
   @ApiProperty({
-    description: propertyMetadata.systemComponentDTOHgConverterIndicator.description,
+    description:
+      propertyMetadata.systemComponentDTOHgConverterIndicator.description,
     example: propertyMetadata.systemComponentDTOHgConverterIndicator.example,
-    name: propertyMetadata.systemComponentDTOHgConverterIndicator.fieldLabels.value,
+    name:
+      propertyMetadata.systemComponentDTOHgConverterIndicator.fieldLabels.value,
   })
   @IsOptional()
   @IsInRange(0, 1, {

--- a/src/duct-waf-workspace/duct-waf.service.ts
+++ b/src/duct-waf-workspace/duct-waf.service.ts
@@ -145,14 +145,14 @@ export class DuctWafWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
 
           await Promise.all(promises);
           resolve(true);
         }
-      })()
+      })();
     });
   }
 }

--- a/src/import-checks/utilities/utils.ts
+++ b/src/import-checks/utilities/utils.ts
@@ -83,9 +83,7 @@ export const checkComponentExistanceInFile = (
   const results = [];
   for (const loc of monPlan.monitoringLocationData) {
     for (const component of loc.componentData) {
-      if (
-        component.componentId !== systemComponent.componentId
-      ) {
+      if (component.componentId !== systemComponent.componentId) {
         results.push(false);
       } else {
         results.push(true);

--- a/src/maps/system-component.map.ts
+++ b/src/maps/system-component.map.ts
@@ -21,7 +21,7 @@ export class SystemComponentMap extends BaseMap<
       componentId: entity.component.componentId,
       componentTypeCode: entity.component.componentTypeCode,
       analyticalPrincipleCode: entity.component.analyticalPrincipleCode,
-      sampleAcquisitionMethodCode:entity.component.sampleAcquisitionMethodCode,
+      sampleAcquisitionMethodCode: entity.component.sampleAcquisitionMethodCode,
       basisCode: entity.component.basisCode,
       manufacturer: entity.component.manufacturer,
       modelVersion: entity.component.modelVersion,

--- a/src/mats-method-workspace/mats-method.service.ts
+++ b/src/mats-method-workspace/mats-method.service.ts
@@ -139,14 +139,14 @@ export class MatsMethodWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/monitor-attribute-workspace/monitor-attribute.service.ts
+++ b/src/monitor-attribute-workspace/monitor-attribute.service.ts
@@ -156,18 +156,23 @@ export class MonitorAttributeWorkspaceService {
                     true,
                   );
                 } else {
-                  await this.createAttribute(locationId, attribute, userId, true);
+                  await this.createAttribute(
+                    locationId,
+                    attribute,
+                    userId,
+                    true,
+                  );
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/monitor-default-workspace/monitor-default.service.ts
+++ b/src/monitor-default-workspace/monitor-default.service.ts
@@ -158,18 +158,23 @@ export class MonitorDefaultWorkspaceService {
                     true,
                   );
                 } else {
-                  await this.createDefault(locationId, monDefault, userId, true);
+                  await this.createDefault(
+                    locationId,
+                    monDefault,
+                    userId,
+                    true,
+                  );
                 }
 
                 innerResolve(true);
               }
-            })()
+            })();
           }),
         );
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/monitor-formula-workspace/monitor-formula.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula.service.ts
@@ -138,7 +138,7 @@ export class MonitorFormulaWorkspaceService {
         formulaId: formula.formulaId,
       });
 
-      if (formulaRecord && ! formulaRecord.endDate) {
+      if (formulaRecord && !formulaRecord.endDate) {
         if (formulaRecord.parameterCode !== formula.parameterCode) {
           errorList.push(
             `[IMPORT9-CRIT1-A] The ParameterCode for Formula ID ${formulaRecord.formulaId} in the database is not equal to the ParameterCode ${formula.formulaId} in the incoming record`,
@@ -205,14 +205,14 @@ export class MonitorFormulaWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
 
           await Promise.all(promises);
           resolve(true);
         }
-      })()
+      })();
     });
   }
 }

--- a/src/monitor-load-workspace/monitor-load.service.ts
+++ b/src/monitor-load-workspace/monitor-load.service.ts
@@ -83,14 +83,14 @@ export class MonitorLoadWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
 
           await Promise.all(promises);
           resolve(true);
         }
-      })()
+      })();
     });
   }
 

--- a/src/monitor-location-workspace/monitor-location.service.ts
+++ b/src/monitor-location-workspace/monitor-location.service.ts
@@ -232,7 +232,10 @@ export class MonitorLocationWorkspaceService {
                     );
                   }
 
-                  if (location.unitFuelData && location.unitFuelData.length > 0) {
+                  if (
+                    location.unitFuelData &&
+                    location.unitFuelData.length > 0
+                  ) {
                     innerPromises.push(
                       this.unitFuelService.importUnitFuel(
                         location.unitFuelData,
@@ -258,7 +261,10 @@ export class MonitorLocationWorkspaceService {
                   );
                 }
 
-                if (location.componentData && location.componentData.length > 0) {
+                if (
+                  location.componentData &&
+                  location.componentData.length > 0
+                ) {
                   innerPromises.push(
                     this.componentService.importComponent(
                       location,
@@ -400,7 +406,7 @@ export class MonitorLocationWorkspaceService {
 
                 await Promise.all(innerPromises);
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
@@ -408,7 +414,7 @@ export class MonitorLocationWorkspaceService {
         await Promise.all(promises);
 
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/monitor-method-workspace/monitor-method.service.ts
+++ b/src/monitor-method-workspace/monitor-method.service.ts
@@ -140,7 +140,7 @@ export class MonitorMethodWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
 
@@ -148,7 +148,7 @@ export class MonitorMethodWorkspaceService {
 
           resolve(true);
         }
-      })()
+      })();
     });
   }
 }

--- a/src/monitor-plan-comment-workspace/monitor-plan-comment.service.ts
+++ b/src/monitor-plan-comment-workspace/monitor-plan-comment.service.ts
@@ -112,14 +112,14 @@ export class MonitorPlanCommentWorkspaceService {
                   }
                 }
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/monitor-plan-workspace/monitor-plan-checks.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan-checks.service.ts
@@ -65,19 +65,19 @@ export class MonitorPlanChecksService {
 
       monitorLocation.supplementalMATSMonitoringMethodData?.forEach(
         (matsMethod, matsMetIdx) => {
-              if(! matsMethod.endDate) {
-                promises.push(
-                new Promise((resolve, _reject) => {
-                  const results = this.matsMethodChecksService.runChecks(
-                    matsMethod,
-                    true,
-                    false,
-                    `locations.${locIdx}.matsMethods.${matsMetIdx}.`,
-                  );
+          if (!matsMethod.endDate) {
+            promises.push(
+              new Promise((resolve, _reject) => {
+                const results = this.matsMethodChecksService.runChecks(
+                  matsMethod,
+                  true,
+                  false,
+                  `locations.${locIdx}.matsMethods.${matsMetIdx}.`,
+                );
 
-                  resolve(results);
-                }),
-              );
+                resolve(results);
+              }),
+            );
           }
         },
       );
@@ -101,18 +101,18 @@ export class MonitorPlanChecksService {
       });
 
       monitorLocation.monitoringSpanData?.forEach((span, spanIdx) => {
-        if(! span.endDate) {
+        if (!span.endDate) {
           promises.push(
-              new Promise((resolve, _reject) => {
-                const results = this.monSpanChecksService.runChecks(
-                    span,
-                    locationId,
-                    true,
-                    false,
-                    `locations.${locIdx}.span.${spanIdx}.`,
-                );
-                resolve(results);
-              }),
+            new Promise((resolve, _reject) => {
+              const results = this.monSpanChecksService.runChecks(
+                span,
+                locationId,
+                true,
+                false,
+                `locations.${locIdx}.span.${spanIdx}.`,
+              );
+              resolve(results);
+            }),
           );
         }
       });
@@ -134,19 +134,19 @@ export class MonitorPlanChecksService {
       });
 
       monitorLocation.monitoringSystemData?.forEach((system, sysIdx) => {
-        if(! system.endDate) {
+        if (!system.endDate) {
           promises.push(
-              new Promise((resolve, _reject) => {
-                const results = this.monSysCheckService.runChecks(
-                    locationId,
-                    system,
-                    true,
-                    false,
-                    `locations.${locIdx}.systems.${sysIdx}.`,
-                );
+            new Promise((resolve, _reject) => {
+              const results = this.monSysCheckService.runChecks(
+                locationId,
+                system,
+                true,
+                false,
+                `locations.${locIdx}.systems.${sysIdx}.`,
+              );
 
-                resolve(results);
-              }),
+              resolve(results);
+            }),
           );
         }
       });

--- a/src/monitor-plan/monitor-plan.service.ts
+++ b/src/monitor-plan/monitor-plan.service.ts
@@ -297,7 +297,7 @@ export class MonitorPlanService {
             }
 
             resolve(components);
-          })()
+          })();
         }),
       );
 
@@ -332,7 +332,7 @@ export class MonitorPlanService {
             }
 
             resolve(systems);
-          })()
+          })();
         }),
       );
 
@@ -378,7 +378,7 @@ export class MonitorPlanService {
             }
 
             resolve(quals);
-          })()
+          })();
         }),
       );
     }

--- a/src/monitor-qualification-workspace/monitor-qualification.service.ts
+++ b/src/monitor-qualification-workspace/monitor-qualification.service.ts
@@ -38,9 +38,8 @@ export class MonitorQualificationWorkspaceService {
     const errorList: string[] = [];
 
     for (const qual of qualifications) {
+      if (qual.endDate) continue; // Don't perform checks on Inactive MonitorQualification Record
 
-      if(qual.endDate) continue; // Don't perform checks on Inactive MonitorQualification Record
-      
       if (qual.qualificationTypeCode !== 'LMEA') {
         qual.monitoringQualificationLMEData.forEach((lmeQual, idx) => {
           if (lmeQual.so2Tons !== null) {

--- a/src/monitor-span-workspace/monitor-span.service.ts
+++ b/src/monitor-span-workspace/monitor-span.service.ts
@@ -183,7 +183,7 @@ export class MonitorSpanWorkspaceService {
             }
 
             innerResolve(true);
-          })()
+          })();
         }),
       );
     }

--- a/src/monitor-system-workspace/monitor-system-checks.service.spec.ts
+++ b/src/monitor-system-workspace/monitor-system-checks.service.spec.ts
@@ -35,7 +35,5 @@ describe('Monitor System Check Service Tests', () => {
     componentCheckService = module.get(ComponentCheckService);
   });
 
-  it('Should return no errors', async () => {
-
-  })
+  it('Should return no errors', async () => {});
 });

--- a/src/monitor-system-workspace/monitor-system.service.ts
+++ b/src/monitor-system-workspace/monitor-system.service.ts
@@ -72,9 +72,7 @@ export class MonitorSystemWorkspaceService {
         system.monitoringSystemComponentData.length > 0
       ) {
         for (const systemComponent of system.monitoringSystemComponentData) {
-          if (
-            !componentIdSet.has(systemComponent.componentId)
-          ) {
+          if (!componentIdSet.has(systemComponent.componentId)) {
             errorList.push(
               `[IMPORT7-CRIT1-A] The workspace database and Monitor Plan Import JSON File does not contain a Component record for ${systemComponent.componentId}`,
             );
@@ -190,7 +188,7 @@ export class MonitorSystemWorkspaceService {
         await Promise.all(promises);
 
         resolve(true);
-      })()
+      })();
     });
   }
 
@@ -293,14 +291,14 @@ export class MonitorSystemWorkspaceService {
                 await Promise.all(innerPromises);
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/stack-pipe/stack-pipe.service.ts
+++ b/src/stack-pipe/stack-pipe.service.ts
@@ -22,7 +22,7 @@ export class StackPipeService {
           retireDate,
         });
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/system-component-workspace/system-component.service.spec.ts
+++ b/src/system-component-workspace/system-component.service.spec.ts
@@ -166,8 +166,9 @@ describe('SystemComponentWorkspaceService', () => {
         .spyOn(repository, 'getSystemComponentByBeginOrEndDate')
         .mockResolvedValue(null);
 
-      jest.spyOn(componentService, 'getComponentByIdentifier')
-          .mockResolvedValue(new ComponentDTO());
+      jest
+        .spyOn(componentService, 'getComponentByIdentifier')
+        .mockResolvedValue(new ComponentDTO());
 
       const result = await service.importSystemComponent(
         '1',

--- a/src/system-component-workspace/system-component.service.ts
+++ b/src/system-component-workspace/system-component.service.ts
@@ -71,14 +71,13 @@ export class SystemComponentWorkspaceService {
     userId: string,
     isImport = false,
   ): Promise<SystemComponentDTO> {
-
     // Saving System Component fields
 
     let component = await this.componentWorkspaceRepository.getComponentByLocIdAndCompId(
       locationId,
       payload.componentId,
     );
-    
+
     if (component) {
       const componentPayload: UpdateComponentBaseDTO = {
         componentId: component.componentId,
@@ -92,7 +91,7 @@ export class SystemComponentWorkspaceService {
         hgConverterIndicator: component.hgConverterIndicator,
         analyzerRangeData: component.analyzerRanges,
       };
-    
+
       await this.componentService.updateComponent(
         locationId,
         component,
@@ -100,7 +99,7 @@ export class SystemComponentWorkspaceService {
         userId,
       );
     }
- 
+
     const systemComponent = await this.getSystemComponent(
       sysId,
       sysComponentRecordId,
@@ -136,11 +135,11 @@ export class SystemComponentWorkspaceService {
 
     if (!component) {
       throw new EaseyException(
-          new Error('Component was not found'),
-          HttpStatus.NOT_FOUND,
-          {
-            componentId: payload.componentId
-          },
+        new Error('Component was not found'),
+        HttpStatus.NOT_FOUND,
+        {
+          componentId: payload.componentId,
+        },
       );
     }
 
@@ -216,14 +215,14 @@ export class SystemComponentWorkspaceService {
 
                 await Promise.all(innerPromises);
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
@@ -149,14 +149,14 @@ export class SystemFuelFlowWorkspaceService {
 
                 await Promise.all(innerPromises);
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/unit-capacity-workspace/unit-capacity.service.ts
+++ b/src/unit-capacity-workspace/unit-capacity.service.ts
@@ -68,14 +68,14 @@ export class UnitCapacityWorkspaceService {
                   );
                 }
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 

--- a/src/unit-control-workspace/unit-control.service.ts
+++ b/src/unit-control-workspace/unit-control.service.ts
@@ -75,7 +75,7 @@ export class UnitControlWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
@@ -83,7 +83,7 @@ export class UnitControlWorkspaceService {
         await Promise.all(promises);
 
         resolve(true);
-      })()
+      })();
     });
   }
 

--- a/src/unit-fuel-workspace/unit-fuel.service.ts
+++ b/src/unit-fuel-workspace/unit-fuel.service.ts
@@ -147,14 +147,14 @@ export class UnitFuelWorkspaceService {
                 }
 
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
 
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 }

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -123,13 +123,13 @@ export class UnitStackConfigurationWorkspaceService {
                   );
                 }
                 innerResolve(true);
-              })()
+              })();
             }),
           );
         }
         await Promise.all(promises);
         resolve(true);
-      })()
+      })();
     });
   }
 

--- a/src/unit/unit.service.ts
+++ b/src/unit/unit.service.ts
@@ -35,7 +35,7 @@ export class UnitService {
           nonLoadBasedIndicator: nonLoadI,
         });
         resolve(true);
-      })()
+      })();
     });
   }
 

--- a/src/utilities/remove-non-reported-values.ts
+++ b/src/utilities/remove-non-reported-values.ts
@@ -110,8 +110,10 @@ async function removeMonitorLocationReportedValues(
     promises.push(monitorSystem(location.monitoringSystemData));
     promises.push(unitCapacity(location.unitCapacityData));
     promises.push(unitControl(location.unitControlData));
-    promises.push(unitFuel(location.unitFuelData))
-    promises.push(suppMatsMonitorMethod(location.supplementalMATSMonitoringMethodData))
+    promises.push(unitFuel(location.unitFuelData));
+    promises.push(
+      suppMatsMonitorMethod(location.supplementalMATSMonitoringMethodData),
+    );
   });
 }
 
@@ -280,7 +282,7 @@ async function qualificationCPMS(qualificationCPMS: CPMSQualificationDTO[]) {
     delete cpms.userId;
     delete cpms.addDate;
     delete cpms.updateDate;
-  })
+  });
 }
 
 async function monitorSystem(systems: MonitorSystemDTO[]) {
@@ -352,7 +354,7 @@ async function unitCapacity(unitCapacities: UnitCapacityDTO[]) {
     delete capacity.addDate;
     delete capacity.updateDate;
     delete capacity.active;
-  })
+  });
 }
 
 async function unitControl(unitControls: UnitControlDTO[]) {
@@ -363,8 +365,7 @@ async function unitControl(unitControls: UnitControlDTO[]) {
     delete control.addDate;
     delete control.updateDate;
     delete control.active;
-
-  })
+  });
 }
 
 async function unitFuel(unitFuels: UnitFuelDTO[]) {
@@ -377,8 +378,7 @@ async function unitFuel(unitFuels: UnitFuelDTO[]) {
     delete fuel.addDate;
     delete fuel.updateDate;
     delete fuel.active;
-
-  })
+  });
 }
 
 async function suppMatsMonitorMethod(matsMethods: MatsMethodDTO[]) {
@@ -389,5 +389,5 @@ async function suppMatsMonitorMethod(matsMethods: MatsMethodDTO[]) {
     delete method.addDate;
     delete method.updateDate;
     delete method.active;
-  })
+  });
 }


### PR DESCRIPTION
## Main Changes

- Corrected the `wafValue` acceptable range in the `DuctWafBaseDTO`.

## Steps to Test

1. Check out any Monitor Plan, then open it and select the section _Rectangular Duct WAFs_.
2. Click the button **Create Rectangular Duct WAF**, and enter the following data:
![screenshot](https://github.com/US-EPA-CAMD/easey-monitor-plan-api/assets/104089016/12b50ddc-f915-412a-be3e-4ac985315c1c)
3. Confirm the item is created.
4. Edit the item, and attempt to change the WAF value to a number greater than or equal to 1, or less than or equal to 0. Confirm an error is displayed.
5. Export the data, then manually adjust the `wafValue` to a number outside the accepted range (`0 < wafValue < 1`). Confirm an error is shown.

## Note

I ran `yarn run format` on the repository. See line 173 of [`src/dtos/duct-waf.dto.ts`](https://github.com/US-EPA-CAMD/easey-monitor-plan-api/pull/540/files#diff-5719892777b65faaaa9e6c3ce065dbae4e6c2d147477eb71be9472227ab28506) for the only change.