### PR TITLE
Fix/5897 formula error messaging

### DIFF
--- a/src/monitor-formula-workspace/monitor-formula-checks.service.spec.ts
+++ b/src/monitor-formula-workspace/monitor-formula-checks.service.spec.ts
@@ -1,0 +1,86 @@
+import { Test } from '@nestjs/testing';
+import { CheckCatalogService } from '@us-epa-camd/easey-common';
+
+import { MonitorFormula } from '../entities/workspace/monitor-formula.entity';
+import { MonitorFormulaBaseDTO } from '../dtos/monitor-formula.dto';
+import { MonitorFormulaChecksService } from './monitor-formula-checks.service';
+import { MonitorFormulaWorkspaceRepository } from './monitor-formula.repository';
+
+jest.mock('@us-epa-camd/easey-common/check-catalog');
+
+const MOCK_ERROR_MSG = 'MOCK_ERROR_MSG';
+const locationId = 'locationId';
+const monitorFormulaBaseDTO = new MonitorFormulaBaseDTO();
+const monitorFormula = new MonitorFormula();
+
+const mockRepository = () => ({
+  getFormula: jest.fn().mockResolvedValue(Promise.resolve(monitorFormula)),
+  getFormulaByLocIdAndFormulaIdentifier: jest
+    .fn()
+    .mockResolvedValue(monitorFormula),
+});
+
+describe('Monitoring Formula Check Service Test', () => {
+  let service: MonitorFormulaChecksService;
+  let repository: MonitorFormulaWorkspaceRepository;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MonitorFormulaChecksService,
+        {
+          provide: MonitorFormulaWorkspaceRepository,
+          useFactory: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get(MonitorFormulaChecksService);
+    repository = module.get(MonitorFormulaWorkspaceRepository);
+    jest
+      .spyOn(CheckCatalogService, 'formatResultMessage')
+      .mockReturnValue(MOCK_ERROR_MSG);
+  });
+
+  describe('Creating a new formula', () => {
+    it('Should get [FORMULA-18-A] error when a duplicate formulaId is provided', async () => {
+      jest
+        .spyOn(repository, 'getFormulaByLocIdAndFormulaIdentifier')
+        .mockResolvedValue(new MonitorFormula());
+      try {
+        await service.runChecks(monitorFormulaBaseDTO, locationId);
+      } catch (err) {
+        expect(err.response.message).toEqual(JSON.stringify([MOCK_ERROR_MSG]));
+      }
+    });
+  });
+
+  describe('Updating an existing formula', () => {
+    it('Should get [FORMULA-18-A] error when the formulaId is updated to one that is already in use', async () => {
+      jest
+        .spyOn(repository, 'getFormulaByLocIdAndFormulaIdentifier')
+        .mockResolvedValue(new MonitorFormula());
+      try {
+        await service.runChecks(monitorFormulaBaseDTO, locationId);
+      } catch (err) {
+        expect(err.response.message).toEqual(JSON.stringify([MOCK_ERROR_MSG]));
+      }
+    });
+
+    it('Should not get an error when the formulaId is updated to the same value', async () => {
+      const testRecordId = 'TEST';
+      jest
+        .spyOn(repository, 'getFormulaByLocIdAndFormulaIdentifier')
+        .mockResolvedValue({
+          ...monitorFormula,
+          id: testRecordId,
+        } as MonitorFormula);
+      const errors = await service.runChecks(
+        monitorFormulaBaseDTO,
+        locationId,
+        testRecordId,
+      );
+      expect(errors).toEqual([]);
+    });
+  });
+});

--- a/src/monitor-formula-workspace/monitor-formula-checks.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula-checks.service.ts
@@ -11,12 +11,15 @@ export class MonitorFormulaChecksService {
   private async duplicateFormulaIdCheck(
     locationId: string,
     monitorFormula: MonitorFormulaBaseDTO,
+    recordId?: string,
   ) {
     const formula = await this.repository.getFormulaByLocIdAndFormulaIdentifier(
       locationId,
       monitorFormula.formulaId,
     );
     if (formula) {
+      if (recordId && formula.id === recordId) return null; // Valid update
+
       return CheckCatalogService.formatResultMessage('FORMULA-18-A', {
         fieldnames: ['formulaId', 'locationId'],
         recordtype: 'Monitor Formula',
@@ -25,10 +28,14 @@ export class MonitorFormulaChecksService {
     return null;
   }
 
-  async runChecks(monitorFormula: MonitorFormulaBaseDTO, locationId: string) {
+  async runChecks(
+    monitorFormula: MonitorFormulaBaseDTO,
+    locationId: string,
+    recordId?: string,
+  ) {
     const errorList = (
       await Promise.all([
-        this.duplicateFormulaIdCheck(locationId, monitorFormula), // FORMULA-18-A
+        this.duplicateFormulaIdCheck(locationId, monitorFormula, recordId), // FORMULA-18-A
       ])
     ).filter(error => error !== null);
 

--- a/src/monitor-formula-workspace/monitor-formula-checks.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula-checks.service.ts
@@ -1,0 +1,47 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { CheckCatalogService, EaseyException } from '@us-epa-camd/easey-common';
+
+import { MonitorFormulaWorkspaceRepository } from './monitor-formula.repository';
+import { MonitorFormulaBaseDTO } from '../dtos/monitor-formula.dto';
+
+@Injectable()
+export class MonitorFormulaChecksService {
+  constructor(private readonly repository: MonitorFormulaWorkspaceRepository) {}
+
+  private async duplicateFormulaIdCheck(
+    locationId: string,
+    monitorFormula: MonitorFormulaBaseDTO,
+  ) {
+    const formula = await this.repository.getFormulaByLocIdAndFormulaIdentifier(
+      locationId,
+      monitorFormula.formulaId,
+    );
+    if (formula) {
+      return CheckCatalogService.formatResultMessage('FORMULA-18-A', {
+        fieldnames: ['formulaId', 'locationId'],
+        recordtype: 'Monitor Formula',
+      });
+    }
+    return null;
+  }
+
+  async runChecks(monitorFormula: MonitorFormulaBaseDTO, locationId: string) {
+    const errorList = (
+      await Promise.all([
+        this.duplicateFormulaIdCheck(locationId, monitorFormula), // FORMULA-18-A
+      ])
+    ).filter(error => error !== null);
+
+    this.throwIfErrors(errorList);
+    return errorList;
+  }
+
+  private throwIfErrors(errorList: string[]) {
+    if (errorList.length > 0) {
+      throw new EaseyException(
+        new Error(JSON.stringify(errorList)),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+}

--- a/src/monitor-formula-workspace/monitor-formula.controller.spec.ts
+++ b/src/monitor-formula-workspace/monitor-formula.controller.spec.ts
@@ -4,6 +4,7 @@ import { HttpModule } from '@nestjs/axios';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 import { DataSource } from 'typeorm';
 
+import { MonitorFormulaChecksService } from './monitor-formula-checks.service';
 import { MonitorFormulaWorkspaceService } from './monitor-formula.service';
 import { MonitorFormulaWorkspaceController } from './monitor-formula.controller';
 import { MonitorFormulaBaseDTO } from '../dtos/monitor-formula.dto';
@@ -31,10 +32,14 @@ const currentUser: CurrentUser = {
 };
 
 const mockMonitorFormulaWorkspaceService = () => ({
-  getFormulas: jest.fn(() => []),
-  getFormula: jest.fn(() => ({})),
-  createFormula: jest.fn(() => ({})),
-  updateFormula: jest.fn(() => ({})),
+  getFormulas: jest.fn(() => Promise.resolve([])),
+  getFormula: jest.fn(() => Promise.resolve({})),
+  createFormula: jest.fn(() => Promise.resolve({})),
+  updateFormula: jest.fn(() => Promise.resolve({})),
+});
+
+const mockMonitorFormulaChecksService = () => ({
+  runChecks: jest.fn(() => Promise.resolve([])),
 });
 
 describe('MonitorFormulaWorkspaceController', () => {
@@ -55,6 +60,10 @@ describe('MonitorFormulaWorkspaceController', () => {
           provide: MonitorFormulaWorkspaceService,
           useFactory: mockMonitorFormulaWorkspaceService,
         },
+        {
+          provide: MonitorFormulaChecksService,
+          useFactory: mockMonitorFormulaChecksService,
+        },
       ],
     }).compile();
 
@@ -67,31 +76,34 @@ describe('MonitorFormulaWorkspaceController', () => {
   });
 
   describe('getFormulas', () => {
-    it('should call the MonitorFormulaWorkspaceService.getFormulas', () => {
-      expect(controller.getFormulas(locationId)).toEqual([]);
+    it('should call the MonitorFormulaWorkspaceService.getFormulas', async () => {
+      const formulas = await controller.getFormulas(locationId);
+      expect(formulas).toEqual([]);
       expect(service.getFormulas).toHaveBeenCalled();
     });
   });
 
   describe('createFormula', () => {
-    it('should call the MonitorFormulaWorkspaceService.createFormula', () => {
-      expect(
-        controller.createFormula(locationId, matsFormulaPayload, currentUser),
-      ).toEqual({});
+    it('should call the MonitorFormulaWorkspaceService.createFormula', async () => {
+      const formula = await controller.createFormula(
+        locationId,
+        matsFormulaPayload,
+        currentUser,
+      );
+      expect(formula).toEqual({});
       expect(service.createFormula).toHaveBeenCalled();
     });
   });
 
   describe('createFormulas', () => {
-    it('should call the MonitorFormulaWorkspaceService.updateFormula', () => {
-      expect(
-        controller.updateFormula(
-          locationId,
-          methodId,
-          matsFormulaPayload,
-          currentUser,
-        ),
-      ).toEqual({});
+    it('should call the MonitorFormulaWorkspaceService.updateFormula', async () => {
+      const formula = await controller.updateFormula(
+        locationId,
+        methodId,
+        matsFormulaPayload,
+        currentUser,
+      );
+      expect(formula).toEqual({});
       expect(service.updateFormula).toHaveBeenCalled();
     });
   });

--- a/src/monitor-formula-workspace/monitor-formula.controller.ts
+++ b/src/monitor-formula-workspace/monitor-formula.controller.ts
@@ -81,7 +81,7 @@ export class MonitorFormulaWorkspaceController {
     @Body() payload: MonitorFormulaBaseDTO,
     @User() user: CurrentUser,
   ): Promise<MonitorFormulaDTO> {
-    await this.checksService.runChecks(payload, locationId);
+    await this.checksService.runChecks(payload, locationId, formulaRecordId);
     return this.service.updateFormula(
       locationId,
       formulaRecordId,

--- a/src/monitor-formula-workspace/monitor-formula.controller.ts
+++ b/src/monitor-formula-workspace/monitor-formula.controller.ts
@@ -4,6 +4,7 @@ import { RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 
 import { MonitorFormulaWorkspaceService } from './monitor-formula.service';
+import { MonitorFormulaChecksService } from './monitor-formula-checks.service';
 import {
   MonitorFormulaBaseDTO,
   MonitorFormulaDTO,
@@ -14,7 +15,10 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 @ApiSecurity('APIKey')
 @ApiTags('Formulas')
 export class MonitorFormulaWorkspaceController {
-  constructor(private readonly service: MonitorFormulaWorkspaceService) {}
+  constructor(
+    private readonly service: MonitorFormulaWorkspaceService,
+    private readonly checksService: MonitorFormulaChecksService,
+  ) {}
 
   @Get()
   @RoleGuard(
@@ -49,11 +53,12 @@ export class MonitorFormulaWorkspaceController {
     type: MonitorFormulaDTO,
     description: 'Creates workspace formula record for a monitor location',
   })
-  createFormula(
+  async createFormula(
     @Param('locId') locationId: string,
     @Body() payload: MonitorFormulaBaseDTO,
     @User() user: CurrentUser,
   ): Promise<MonitorFormulaDTO> {
+    await this.checksService.runChecks(payload, locationId);
     return this.service.createFormula(locationId, payload, user.userId);
   }
 
@@ -70,12 +75,13 @@ export class MonitorFormulaWorkspaceController {
     type: MonitorFormulaDTO,
     description: 'Updates workspace formula record for a monitor location',
   })
-  updateFormula(
+  async updateFormula(
     @Param('locId') locationId: string,
     @Param('formulaId') formulaRecordId: string,
     @Body() payload: MonitorFormulaBaseDTO,
     @User() user: CurrentUser,
   ): Promise<MonitorFormulaDTO> {
+    await this.checksService.runChecks(payload, locationId);
     return this.service.updateFormula(
       locationId,
       formulaRecordId,

--- a/src/monitor-formula-workspace/monitor-formula.module.ts
+++ b/src/monitor-formula-workspace/monitor-formula.module.ts
@@ -1,13 +1,14 @@
+import { HttpModule } from '@nestjs/axios';
 import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { HttpModule } from '@nestjs/axios';
 
-import { MonitorFormulaWorkspaceController } from './monitor-formula.controller';
-import { MonitorFormulaWorkspaceService } from './monitor-formula.service';
-import { MonitorFormulaWorkspaceRepository } from './monitor-formula.repository';
 import { MonitorFormulaMap } from '../maps/monitor-formula.map';
 import { MonitorPlanWorkspaceModule } from '../monitor-plan-workspace/monitor-plan.module';
 import { UsedIdentifierRepository } from '../used-identifier/used-identifier.repository';
+import { MonitorFormulaChecksService } from './monitor-formula-checks.service';
+import { MonitorFormulaWorkspaceController } from './monitor-formula.controller';
+import { MonitorFormulaWorkspaceRepository } from './monitor-formula.repository';
+import { MonitorFormulaWorkspaceService } from './monitor-formula.service';
 
 @Module({
   imports: [
@@ -20,16 +21,18 @@ import { UsedIdentifierRepository } from '../used-identifier/used-identifier.rep
   ],
   controllers: [MonitorFormulaWorkspaceController],
   providers: [
-    MonitorFormulaWorkspaceRepository,
-    UsedIdentifierRepository,
-    MonitorFormulaWorkspaceService,
+    MonitorFormulaChecksService,
     MonitorFormulaMap,
+    MonitorFormulaWorkspaceRepository,
+    MonitorFormulaWorkspaceService,
+    UsedIdentifierRepository,
   ],
   exports: [
-    TypeOrmModule,
+    MonitorFormulaChecksService,
+    MonitorFormulaMap,
     MonitorFormulaWorkspaceRepository,
     MonitorFormulaWorkspaceService,
-    MonitorFormulaMap,
+    TypeOrmModule,
   ],
 })
 export class MonitorFormulaWorkspaceModule {}


### PR DESCRIPTION
## Related Issues:
- [#5897](https://github.com/US-EPA-CAMD/easey-ui/issues/5897)

## Main Changes:
- Added a screen check for `FORMULA-18-A` when updating or creating a Monitor Formula. A `formulaId` should be unique for any given `locationId`.
- Added unit tests for the new `MonitorFormulaChecksService`.

## Steps to Test:
1. Follow the testing steps listed in the corresponding issue.
2. Open any formula for editing, change its Formula ID to match another Formula ID in the same monitoring location, and click _Save and Close_. The `FORMULA-18-A` error should show again.
3. Open any formula for editing and click _Save and Close_ without changing anything. the `FORMULA-18-A` error should _not_ show.

## TODO:
- [ ] Merge this in Sprint 5 **after the ICAM / TypeORM changes have been tested**.