### PR TITLE
Fix/6185 typeorm null changes

### DIFF
--- a/src/component-workspace/component.service.ts
+++ b/src/component-workspace/component.service.ts
@@ -127,7 +127,7 @@ export class ComponentWorkspaceService {
                   component.componentId,
                 );
 
-                if (compRecord === undefined) {
+                if (!compRecord) {
                   // Check used_identifier table to see if the componentId has already
                   // been used, and if so grab that component record for update
                   let usedIdentifier = await this.usedIdRepo.getBySpecs(

--- a/src/duct-waf-workspace/duct-waf.service.ts
+++ b/src/duct-waf-workspace/duct-waf.service.ts
@@ -131,7 +131,7 @@ export class DuctWafWorkspaceService {
                   ductWaf.wafEndHour,
                 );
 
-                if (ductWafRecord !== undefined) {
+                if (ductWafRecord) {
                   await this.updateDuctWaf(
                     locationId,
                     ductWafRecord.id,

--- a/src/import-checks/mp-file-checks/formula.ts
+++ b/src/import-checks/mp-file-checks/formula.ts
@@ -22,15 +22,12 @@ export const Check9 = new Check(
       const monLoc = await getMonLocId(loc, facility, monPlan.orisCode);
 
       for (const formula of loc.monitoringFormulaData) {
-        const Form = await entityManager.findOneBy(MonitorFormula, {
+        const form = await entityManager.findOneBy(MonitorFormula, {
           locationId: monLoc.id,
           formulaId: formula.formulaId,
         });
 
-        if (
-          Form !== undefined &&
-          Form.parameterCode !== formula.parameterCode
-        ) {
+        if (form && form.parameterCode !== formula.parameterCode) {
           result.addError(
             'CRIT1-A',
             `The ParameterCode ${formula.parameterCode} for UnitStackPipeID ${loc.unitId}/${loc.stackPipeId} and FormulaID ${formula.formulaId} does not match the parameter code in the Workspace database.`,
@@ -38,9 +35,9 @@ export const Check9 = new Check(
         }
 
         if (
-          Form !== undefined &&
+          form !== null &&
           formula.formulaCode !== null &&
-          Form.formulaCode !== formula.formulaCode
+          form.formulaCode !== formula.formulaCode
         ) {
           result.addError(
             'CRIT1-B',

--- a/src/import-checks/mp-file-checks/system.ts
+++ b/src/import-checks/mp-file-checks/system.ts
@@ -30,7 +30,7 @@ export const Check5 = new Check(
           monitoringSystemId: system.monitoringSystemId,
         });
 
-        if (sys !== null && sys.systemTypeCode !== system.systemTypeCode) {
+        if (sys && sys.systemTypeCode !== system.systemTypeCode) {
           result.addError(
             'CRIT1-A',
             `The system type ${system.systemTypeCode} for UnitStackPipeID ${loc.unitId}/${loc.stackPipeId} and MonitoringSystemID ${system.monitoringSystemId} does not match the system type in the Workspace database.`,
@@ -117,7 +117,7 @@ export const Check31 = new Check(
               monitoringSystemId: system.monitoringSystemId,
             });
 
-            if (sys !== null && !validTypeCodes.includes(sys.systemTypeCode)) {
+            if (sys && !validTypeCodes.includes(sys.systemTypeCode)) {
               result.addError(
                 'CRIT1-A',
                 'You have reported a System Fuel Flow record for a system that is not a fuel flow system. It is not appropriate to report a System Fuel Flow record for any other SystemTypeCode than OILM, OILV, GAS, LTGS, or LTOL.',

--- a/src/import-checks/mp-file-checks/system.ts
+++ b/src/import-checks/mp-file-checks/system.ts
@@ -30,7 +30,7 @@ export const Check5 = new Check(
           monitoringSystemId: system.monitoringSystemId,
         });
 
-        if (sys !== undefined && sys.systemTypeCode !== system.systemTypeCode) {
+        if (sys !== null && sys.systemTypeCode !== system.systemTypeCode) {
           result.addError(
             'CRIT1-A',
             `The system type ${system.systemTypeCode} for UnitStackPipeID ${loc.unitId}/${loc.stackPipeId} and MonitoringSystemID ${system.monitoringSystemId} does not match the system type in the Workspace database.`,
@@ -60,21 +60,21 @@ export const Check7 = new Check(
 
       for (const system of loc.monitoringSystemData) {
         for (const systemComponent of system.monitoringSystemComponentData) {
-          const Comp = await entityManager.findOneBy(Component, {
+          const comp = await entityManager.findOneBy(Component, {
             locationId: monLoc.id,
             componentId: systemComponent.componentId,
           });
 
           let checkComponentExists;
 
-          if (Comp === undefined) {
-            checkComponentExists = await checkComponentExistanceInFile(
+          if (!comp) {
+            checkComponentExists = checkComponentExistanceInFile(
               monPlan,
               systemComponent,
             );
           }
 
-          if (Comp === undefined && checkComponentExists === false) {
+          if (!comp && checkComponentExists === false) {
             result.addError(
               'CRIT1-A',
               `The workspace database and Monitor Plan Import File does not contain a Component record for ${systemComponent.componentId}`,
@@ -117,10 +117,7 @@ export const Check31 = new Check(
               monitoringSystemId: system.monitoringSystemId,
             });
 
-            if (
-              sys !== undefined &&
-              !validTypeCodes.includes(sys.systemTypeCode)
-            ) {
+            if (sys !== null && !validTypeCodes.includes(sys.systemTypeCode)) {
               result.addError(
                 'CRIT1-A',
                 'You have reported a System Fuel Flow record for a system that is not a fuel flow system. It is not appropriate to report a System Fuel Flow record for any other SystemTypeCode than OILM, OILV, GAS, LTGS, or LTOL.',

--- a/src/import-checks/utilities/utils.ts
+++ b/src/import-checks/utilities/utils.ts
@@ -28,7 +28,7 @@ export const getMonLocId = async (
       facId: facility,
     });
 
-    if (stackPipe === null) {
+    if (!stackPipe) {
       throw new BadRequestException(
         CheckCatalogService.formatMessage(
           'The database does not contain a record for Stack Pipe [stackPipe] and Facility: [orisCode]',
@@ -46,7 +46,7 @@ export const getMonLocId = async (
       facId: facility,
     });
 
-    if (unit === null) {
+    if (!unit) {
       throw new BadRequestException(
         CheckCatalogService.formatMessage(
           'The database does not contain a record for Unit [unit] and Facility: [orisCode]',
@@ -70,7 +70,7 @@ export const getFacIdFromOris = async (orisCode: number): Promise<number> => {
     orisCode,
   });
 
-  if (facResult === null) {
+  if (!facResult) {
     return null;
   }
 

--- a/src/import-checks/utilities/utils.ts
+++ b/src/import-checks/utilities/utils.ts
@@ -28,7 +28,7 @@ export const getMonLocId = async (
       facId: facility,
     });
 
-    if (stackPipe === undefined) {
+    if (stackPipe === null) {
       throw new BadRequestException(
         CheckCatalogService.formatMessage(
           'The database does not contain a record for Stack Pipe [stackPipe] and Facility: [orisCode]',
@@ -46,7 +46,7 @@ export const getMonLocId = async (
       facId: facility,
     });
 
-    if (unit === undefined) {
+    if (unit === null) {
       throw new BadRequestException(
         CheckCatalogService.formatMessage(
           'The database does not contain a record for Unit [unit] and Facility: [orisCode]',
@@ -70,7 +70,7 @@ export const getFacIdFromOris = async (orisCode: number): Promise<number> => {
     orisCode,
   });
 
-  if (facResult === undefined) {
+  if (facResult === null) {
     return null;
   }
 

--- a/src/monitor-attribute-workspace/monitor-attribute.service.ts
+++ b/src/monitor-attribute-workspace/monitor-attribute.service.ts
@@ -140,7 +140,7 @@ export class MonitorAttributeWorkspaceService {
                   attribute.beginDate,
                 );
 
-                if (attributeRecord !== undefined) {
+                if (attributeRecord) {
                   await this.updateAttribute(
                     locationId,
                     attributeRecord.id,

--- a/src/monitor-default-workspace/monitor-default.service.ts
+++ b/src/monitor-default-workspace/monitor-default.service.ts
@@ -142,7 +142,7 @@ export class MonitorDefaultWorkspaceService {
                   monDefault.endHour,
                 );
 
-                if (monDefaultRecord !== undefined) {
+                if (monDefaultRecord) {
                   await this.updateDefault(
                     locationId,
                     monDefaultRecord.id,

--- a/src/monitor-formula-workspace/monitor-formula.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula.service.ts
@@ -166,7 +166,7 @@ export class MonitorFormulaWorkspaceService {
                   formula.formulaId,
                 );
 
-                if (formulaRecord === undefined) {
+                if (!formulaRecord) {
                   // Check used_identifier table to see if the formulaId has already
                   // been used, and if so grab that monitor-formula record for update
                   let usedIdentifier = await this.usedIdRepo.getBySpecs(
@@ -181,7 +181,7 @@ export class MonitorFormulaWorkspaceService {
                     });
                 }
 
-                if (formulaRecord !== undefined) {
+                if (formulaRecord) {
                   await this.updateFormula(
                     locationId,
                     formulaRecord.id,

--- a/src/monitor-load-workspace/monitor-load.service.ts
+++ b/src/monitor-load-workspace/monitor-load.service.ts
@@ -63,7 +63,7 @@ export class MonitorLoadWorkspaceService {
                   load.endHour,
                 );
 
-                if (loadRecord !== undefined) {
+                if (loadRecord) {
                   await this.updateLoad(
                     locationId,
                     loadRecord.id,

--- a/src/monitor-location-workspace/monitor-location.service.ts
+++ b/src/monitor-location-workspace/monitor-location.service.ts
@@ -109,7 +109,7 @@ export class MonitorLocationWorkspaceService {
         facilityId,
       );
 
-      if (unit === undefined) {
+      if (!unit) {
         throw new BadRequestException(
           CheckCatalogService.formatMessage(
             'The database does not contain a record for Unit [unit] and Facility: [orisCode]',
@@ -131,7 +131,7 @@ export class MonitorLocationWorkspaceService {
         facilityId,
       );
 
-      if (stackPipe === undefined) {
+      if (!stackPipe) {
         throw new BadRequestException(
           CheckCatalogService.formatMessage(
             'The database does not contain a record for Stack Pipe [stackPipe] and Facility: [orisCode]',

--- a/src/monitor-method-workspace/monitor-method.service.ts
+++ b/src/monitor-method-workspace/monitor-method.service.ts
@@ -125,7 +125,7 @@ export class MonitorMethodWorkspaceService {
                   method.endHour,
                 );
 
-                if (methodRecord !== undefined) {
+                if (methodRecord) {
                   await this.updateMethod(
                     methodRecord.id,
                     method,

--- a/src/monitor-system-workspace/monitor-system.service.ts
+++ b/src/monitor-system-workspace/monitor-system.service.ts
@@ -235,7 +235,7 @@ export class MonitorSystemWorkspaceService {
                   system.monitoringSystemId,
                 );
 
-                if (systemRecord === undefined) {
+                if (!systemRecord) {
                   // Check used_identifier table to see if the sysIdentifier has already
                   // been used, and if so grab that monitor-system record for update
                   let usedIdentifier = await this.usedIdRepo.getBySpecs(
@@ -250,7 +250,7 @@ export class MonitorSystemWorkspaceService {
                     });
                 }
 
-                if (systemRecord !== undefined) {
+                if (systemRecord) {
                   await this.updateSystem(
                     systemRecord.id,
                     system,

--- a/src/unit-fuel-workspace/unit-fuel.service.ts
+++ b/src/unit-fuel-workspace/unit-fuel.service.ts
@@ -126,7 +126,7 @@ export class UnitFuelWorkspaceService {
                   unitFuel.endDate,
                 );
 
-                if (unitFuelRecord !== undefined) {
+                if (unitFuelRecord) {
                   await this.updateUnitFuel(
                     locationId,
                     unitId,

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -109,7 +109,7 @@ export class UnitStackConfigurationWorkspaceService {
                   stackPipe.id,
                 );
 
-                if (unitStackConfigRecord !== undefined) {
+                if (unitStackConfigRecord) {
                   await this.updateUnitStackConfig(
                     unitStackConfigRecord.id,
                     unitStackConfig,


### PR DESCRIPTION
## Changes

In the previous changes made in response to the TypeORM update, I overlooked one breaking change noted in the [release notes](https://github.com/typeorm/typeorm/releases/tag/0.3.0):
> findOne and QueryBuilder.getOne() now return null instead of undefined in the case if it didn't find anything in the database.
Logically it makes more sense to return null.

This means that all explicit comparisons against `undefined` should be changed to `null` (alternatively, since the method will return either a complex type or `null`, one can just check if it is falsy).