### PR TITLE
fix:remove updating  monitoring plan userId and update date

### DIFF
--- a/src/check-out/check-out.controller.ts
+++ b/src/check-out/check-out.controller.ts
@@ -77,7 +77,7 @@ export class CheckOutController {
   ) {
     const result = await this.ucoService.getCheckedOutConfiguration(planId);
     if (result && (await this.ucoService.checkInConfiguration(planId))) {
-      await this.mpWksService.updateDateAndUserId(planId, user.userId);
+      return
     }
   }
 }

--- a/src/check-out/check-out.controller.ts
+++ b/src/check-out/check-out.controller.ts
@@ -76,8 +76,6 @@ export class CheckOutController {
     @User() user: CurrentUser,
   ) {
     const result = await this.ucoService.getCheckedOutConfiguration(planId);
-    if (result && (await this.ucoService.checkInConfiguration(planId))) {
-      return
-    }
+    if (result) await this.ucoService.checkInConfiguration(planId)
   }
 }


### PR DESCRIPTION
## Ticket
[Checking Out and In a Monitoring Plan Changes Update date](https://github.com/US-EPA-CAMD/easey-ui/issues/5208)

## Change

- Removed updating `userid` and `update_date` from `monitor_plan` when user check in.


