### PR TITLE
feat added unitCapacities, unitControls, unitFuelsin last-updated endpoint

### DIFF
--- a/src/entities/monitor-plan.entity.ts
+++ b/src/entities/monitor-plan.entity.ts
@@ -15,6 +15,9 @@ import { MonitorLocation } from './monitor-location.entity';
 import { MonitorPlanComment } from './monitor-plan-comment.entity';
 import { UnitStackConfiguration } from './unit-stack-configuration.entity';
 import { MonitorPlanReportingFrequency } from './monitor-plan-reporting-freq.entity';
+import { UnitCapacity } from './unit-capacity.entity';
+import { UnitControl } from './unit-control.entity';
+import { UnitFuel } from './unit-fuel.entity';
 
 @Entity({ name: 'camdecmps.monitor_plan' })
 export class MonitorPlan extends BaseEntity {
@@ -149,6 +152,12 @@ export class MonitorPlan extends BaseEntity {
   reportingFrequencies: MonitorPlanReportingFrequency[];
 
   unitStackConfigurations: UnitStackConfiguration[];
+
+  unitCapacities?: UnitCapacity[];
+
+  unitControls?: UnitControl[];
+
+  unitFuels?:UnitFuel[];
 
   @Column({ name: 'last_evaluated_date' })
   lastEvaluatedDate: Date;

--- a/src/monitor-configurations/monitor-configurations.module.ts
+++ b/src/monitor-configurations/monitor-configurations.module.ts
@@ -6,6 +6,9 @@ import { PlantModule } from '../plant/plant.module';
 import { UnitStackConfigurationModule } from '../unit-stack-configuration/unit-stack-configuration.module';
 import { MonitorConfigurationsController } from './monitor-configurations.controller';
 import { MonitorConfigurationsService } from './monitor-configurations.service';
+import { UnitCapacityModule } from 'src/unit-capacity/unit-capacity.module';
+import { UnitControlModule } from 'src/unit-control/unit-control.module';
+import { UnitFuelModule } from 'src/unit-fuel/unit-fuel.module';
 
 @Module({
   imports: [
@@ -13,6 +16,9 @@ import { MonitorConfigurationsService } from './monitor-configurations.service';
     MonitorLocationModule,
     PlantModule,
     UnitStackConfigurationModule,
+    UnitCapacityModule,
+    UnitControlModule,
+    UnitFuelModule
   ],
   controllers: [MonitorConfigurationsController],
   providers: [MonitorConfigurationsService],

--- a/src/monitor-configurations/monitor-configurations.service.spec.ts
+++ b/src/monitor-configurations/monitor-configurations.service.spec.ts
@@ -12,6 +12,9 @@ import { MonitorPlanRepository } from '../monitor-plan/monitor-plan.repository';
 import { MonitorPlanService } from '../monitor-plan/monitor-plan.service';
 import { UnitStackConfigurationRepository } from '../unit-stack-configuration/unit-stack-configuration.repository';
 import { MonitorConfigurationsService } from './monitor-configurations.service';
+import { UnitControlRepository } from '../unit-control/unit-control.repository';
+import { UnitCapacityRepository } from '../unit-capacity/unit-capacity.repository';
+import { UnitFuelRepository } from '../unit-fuel/unit-fuel.repository';
 
 const MON_PLAN_ID = 'MON_PLAN_ID';
 const ORIS_CODE = 2;
@@ -71,6 +74,9 @@ describe('MonitorConfigurationsService', () => {
         },
         UnitStackConfigurationRepository,
         MonitorLocationRepository,
+        UnitControlRepository,
+        UnitCapacityRepository,
+        UnitFuelRepository
       ],
     }).compile();
 

--- a/src/monitor-configurations/monitor-configurations.service.ts
+++ b/src/monitor-configurations/monitor-configurations.service.ts
@@ -8,6 +8,9 @@ import { MonitorPlanRepository } from '../monitor-plan/monitor-plan.repository';
 import { EntityManager, In, MoreThanOrEqual } from 'typeorm';
 import { UnitStackConfigurationRepository } from '../unit-stack-configuration/unit-stack-configuration.repository';
 import { MonitorLocationRepository } from '../monitor-location/monitor-location.repository';
+import { UnitCapacityRepository } from '../unit-capacity/unit-capacity.repository';
+import { UnitControlRepository } from '../unit-control/unit-control.repository';
+import { UnitFuelRepository } from '../unit-fuel/unit-fuel.repository';
 
 @Injectable()
 export class MonitorConfigurationsService {
@@ -17,6 +20,9 @@ export class MonitorConfigurationsService {
     private readonly monitorPlanRepository: MonitorPlanRepository,
     private readonly plantRepository: PlantRepository,
     private readonly uscRepository: UnitStackConfigurationRepository,
+    private readonly unitCapacityRepository: UnitCapacityRepository,
+    private readonly unitControlRepository: UnitControlRepository,
+    private readonly unitFuelRepository: UnitFuelRepository,
     private readonly map: MonitorPlanMap,
   ) {}
 
@@ -84,6 +90,18 @@ export class MonitorConfigurationsService {
     );
   }
 
+  async lookupUnitCapacitys(locations: string[], config:MonitorPlan){
+    config.unitCapacities =  await this.unitCapacityRepository.getUnitCapacitiesByLocationIds(locations);
+  }
+
+  async lookupUnitControls(locations: string[], config:MonitorPlan){
+    config.unitControls =  await this.unitControlRepository.getUnitControlsByLocationIds(locations);
+  }
+
+  async lookupUnitFuel(locations: string[], config:MonitorPlan){
+    config.unitFuels =  await this.unitFuelRepository.getUnitFuelByLocationIds(locations);
+  }
+
   async getConfigurationsByLastUpdated(
     queryTime: string,
   ): Promise<LastUpdatedConfigDTO> {
@@ -119,6 +137,9 @@ export class MonitorConfigurationsService {
         locationList.push(loc.id);
       }
       promises.push(this.lookupUnitStacks(locationList, config));
+      promises.push(this.lookupUnitCapacitys(locationList, config));
+      promises.push(this.lookupUnitControls(locationList, config));
+      promises.push(this.lookupUnitFuel(locationList, config));
     }
 
     await Promise.all(promises);

--- a/src/unit-capacity/unit-capacity.repository.ts
+++ b/src/unit-capacity/unit-capacity.repository.ts
@@ -23,6 +23,17 @@ export class UnitCapacityRepository extends Repository<UnitCapacity> {
     return query.getMany();
   }
 
+  async getUnitCapacitiesByLocationIds(
+    locationIds: string[]
+  ): Promise<UnitCapacity[]> {
+    const query = this.createQueryBuilder('uc')
+      .innerJoin('uc.unit', 'u')
+      .innerJoin('u.location', 'l')
+      .where('l.id IN (:...locationIds)', { locationIds })
+
+    return query.getMany();
+  }
+
   async getUnitCapacitiesByUnitIds(ids: number[]): Promise<UnitCapacity[]> {
     const query = this.createQueryBuilder('uc')
       .innerJoinAndSelect('uc.unit', 'u')

--- a/src/unit-control/unit-control.repository.ts
+++ b/src/unit-control/unit-control.repository.ts
@@ -16,4 +16,12 @@ export class UnitControlRepository extends Repository<UnitControl> {
       .andWhere('u.id = :unitId', { unitId })
       .getMany();
   }
+
+  async getUnitControlsByLocationIds(locationIds: string[]): Promise<UnitControl[]> {
+    return this.createQueryBuilder('uc')
+      .innerJoin('uc.unit', 'u')
+      .innerJoin('u.location', 'l')
+      .where('l.id IN (:...locationIds)', { locationIds })
+      .getMany();
+  }
 }

--- a/src/unit-fuel/unit-fuel.repository.ts
+++ b/src/unit-fuel/unit-fuel.repository.ts
@@ -16,4 +16,12 @@ export class UnitFuelRepository extends Repository<UnitFuel> {
       .andWhere('u.id = :unitId', { unitId })
       .getMany();
   }
+
+  async getUnitFuelByLocationIds(locationIds: string[]): Promise<UnitFuel[]> {
+    return this.createQueryBuilder('uf')
+      .innerJoin('uf.unit', 'u')
+      .innerJoin('u.location', 'l')
+      .where('l.id IN (:...locationIds)', { locationIds })
+      .getMany();
+  }
 }


### PR DESCRIPTION
## Ticket
[Monitoring Plan Management Configurations Last-Updated Endpoint - Missing Unit Capacity, Control and Fuel Data](https://github.com/US-EPA-CAMD/easey-ui/issues/6368)

## Chages

1. Added unitCapacities,  unitControls, in the last-updated endpoint
2. Update testcase