### PR TITLE
Fix/6366 disallow checkout

### DIFF
--- a/src/user-check-out/user-check-out.service.spec.ts
+++ b/src/user-check-out/user-check-out.service.spec.ts
@@ -59,6 +59,9 @@ describe('UserCheckOutService', () => {
 
   describe('checkOutConfiguration', () => {
     it('should check out a configuration and return it', async () => {
+      jest
+        .spyOn(service as any, 'ensureNoEvaluationOrSubmissionInProgress')
+        .mockResolvedValue(true);
       const result = await service.checkOutConfiguration(null, null);
       expect(result).toEqual(userCheckoutDto);
     });


### PR DESCRIPTION
## Related Issues

- [#6366](https://github.com/US-EPA-CAMD/easey-ui/issues/6366)

## Main Changes

- Duplicated the logic used to check of a monitor plan evaluation or submission is in progress from `checkInConfiguration` to `checkOutConfiguration`.