### PR TITLE
fix:update indicatorCOde to fuelIndicatorCode

### DIFF
--- a/src/entities/unit-control.entity.ts
+++ b/src/entities/unit-control.entity.ts
@@ -48,7 +48,7 @@ export class UnitControl extends BaseEntity {
   updateDate: Date;
 
   @Column({ select: false, name: 'indicator_cd', update: false, insert: false })
-  indicatorCode?: string
+  fuelIndicatorCode?: string
 
   @ManyToOne(
     () => Unit,

--- a/src/unit-control/unit-control.repository.ts
+++ b/src/unit-control/unit-control.repository.ts
@@ -18,7 +18,7 @@ export class UnitControlRepository extends Repository<UnitControl> {
   }
 
   async getUnitControlsByLocationIds(locationIds: string[]): Promise<UnitControl[]> {
-    return this.createQueryBuilder('uc').addSelect('uc.indicatorCode')
+    return this.createQueryBuilder('uc').addSelect('uc.fuelIndicatorCode')
       .innerJoin('uc.unit', 'u')
       .innerJoin('u.location', 'l')
       .where('l.id IN (:...locationIds)', { locationIds })


### PR DESCRIPTION
## Ticket
[Monitoring Plan Management Configurations Last-Updated Endpoint - Add Missing Unit Control Indicator Code Field ](https://github.com/US-EPA-CAMD/easey-ui/issues/6293)

## Changes

- Changed `indicatorCode` to `fuelIndicatorCode`

#### Note: Previous PR: https://github.com/US-EPA-CAMD/easey-monitor-plan-api/pull/575