### PR TITLE
Feature/5995 configuration manager

### DIFF
--- a/src/dtos/single-unit-monitor-plan-request.dto.ts
+++ b/src/dtos/single-unit-monitor-plan-request.dto.ts
@@ -4,13 +4,13 @@ import { IsInt, IsNotEmpty, IsString } from 'class-validator';
 
 export class SingleUnitMonitorPlanRequestDTO {
   @ApiProperty({
-    description: propertyMetadata.facilityId.description,
-    example: propertyMetadata.facilityId.example,
-    name: propertyMetadata.facilityId.fieldLabels.value,
+    description: propertyMetadata.monitorPlanDTOOrisCode.description,
+    example: propertyMetadata.monitorPlanDTOOrisCode.example,
+    name: propertyMetadata.monitorPlanDTOOrisCode.fieldLabels.value,
   })
   @IsNotEmpty()
   @IsInt()
-  facilityId: number;
+  orisCode: number;
 
   @ApiProperty({
     description: propertyMetadata.unitId.description,

--- a/src/import-checks/import-checks.service.ts
+++ b/src/import-checks/import-checks.service.ts
@@ -53,6 +53,14 @@ export class ImportChecksService {
     errorList.push(...this.unitStackService.runUnitStackChecks(monPlan));
     this.checkIfThrows(errorList);
 
+    // Stack Pipe Checks
+    errorList.push(
+      ...(await this.stackPipeService.runStackPipeChecks(
+        monPlan.monitoringLocationData.filter(location => location.stackPipeId),
+        facilityId,
+      )),
+    );
+
     const databaseLocations = await this.monitorLocationService.getMonitorLocationsByFacilityAndOris(
       monPlan,
       facilityId,
@@ -67,16 +75,6 @@ export class ImportChecksService {
           ...(await this.unitService.runUnitChecks(
             location,
             monPlan.orisCode,
-            facilityId,
-          )),
-        );
-      }
-
-      // Stack Pipe Checks
-      if (location.stackPipeId) {
-        errorList.push(
-          ...(await this.stackPipeService.runStackPipeChecks(
-            location,
             facilityId,
           )),
         );

--- a/src/maps/unit.map.ts
+++ b/src/maps/unit.map.ts
@@ -20,8 +20,11 @@ export class UnitMap extends BaseMap<Unit | UnitWorkspace, UnitDTO> {
   }
 
   private getEndDate(entity: Unit | UnitWorkspace): Date {
+    const opStatuses = entity.opStatuses;
+    if (!opStatuses) return null;
+
     const unitRetireDateEpoch = Math.min(
-      ...(entity.opStatuses as Array<UnitOpStatus | UnitOpStatusWorkspace>)
+      ...(opStatuses as Array<UnitOpStatus | UnitOpStatusWorkspace>)
         .filter(s => s.opStatusCode === 'RET')
         .map(s => new Date(s.beginDate).getTime()),
     );
@@ -38,7 +41,7 @@ export class UnitMap extends BaseMap<Unit | UnitWorkspace, UnitDTO> {
       beginDate: this.getBeginDate(entity),
       endDate: this.getEndDate(entity),
       userId: entity.userId,
-      addDate: entity.addDate.toISOString() ?? null,
+      addDate: entity.addDate.toISOString(),
       updateDate: entity.updateDate?.toISOString() ?? null,
       nonLoadBasedIndicator: entity.nonLoadBasedIndicator,
     };

--- a/src/monitor-location-workspace/monitor-location.service.ts
+++ b/src/monitor-location-workspace/monitor-location.service.ts
@@ -381,6 +381,7 @@ export class MonitorLocationWorkspaceService {
             this.unitService.importUnit(
               unitRecord,
               location.nonLoadBasedIndicator,
+              userId,
               trx,
             ),
           );
@@ -436,6 +437,7 @@ export class MonitorLocationWorkspaceService {
             this.stackPipeService.updateStackPipe(
               stackPipeRecord,
               location.retireDate,
+              userId,
               trx,
             ),
           );

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -97,7 +97,7 @@ export class MonitorPlanWorkspaceController {
   @Post('single-unit')
   @RoleGuard(
     {
-      bodyParam: 'facilityId',
+      bodyParam: 'orisCode',
     },
     LookupType.Facility,
   )
@@ -113,7 +113,7 @@ export class MonitorPlanWorkspaceController {
   ) {
     return this.service.createNewSingleUnitMonitorPlan(
       payload.unitId,
-      payload.facilityId,
+      payload.orisCode,
       user.userId,
       draft,
     );

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -132,7 +132,7 @@ export class MonitorPlanWorkspaceController {
     description:
       'Revert workspace monitor plan back to official submitted record',
   })
-  revertToOfficialRecord(@Param('planId') planId: string): Promise<void> {
+  revertToOfficialRecord(@Param('planId') planId: string) {
     return this.service.revertToOfficialRecord(planId);
   }
 }

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -437,7 +437,7 @@ export class MonitorPlanWorkspaceService {
 
   async createNewSingleUnitMonitorPlan(
     unitId: string,
-    facilityId: number,
+    orisCode: number,
     userId: string,
     draft = false,
   ) {
@@ -453,8 +453,9 @@ export class MonitorPlanWorkspaceService {
       .select('mp.id', 'id')
       .innerJoin('mp.locations', 'l')
       .innerJoin('l.unit', 'u')
+      .innerJoin('u.plant', 'p')
       .where('u.name = :unitId', { unitId })
-      .andWhere('u.facId = :facId', { facId: facilityId })
+      .andWhere('p.orisCode = :orisCode', { orisCode })
       .getRawMany();
     if (associatedPlans.length > 0) {
       this.logger.debug(
@@ -469,7 +470,7 @@ export class MonitorPlanWorkspaceService {
       );
     }
 
-    const orisCode = await this.plantService.getOrisCodeFromFacId(facilityId);
+    const facilityId = await this.plantService.getFacIdFromOris(orisCode);
     const location = await this.monitorLocationService.getOrCreateUnitLocation({
       create: true,
       facilityId,

--- a/src/stack-pipe-workspace/stack-pipe.module.ts
+++ b/src/stack-pipe-workspace/stack-pipe.module.ts
@@ -2,6 +2,7 @@ import { HttpModule } from '@nestjs/axios';
 import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { EmissionEvaluationModule } from '../emission-evaluation/emission-evaluation.module';
 import { StackPipeMap } from '../maps/stack-pipe.map';
 import { MonitorLocationWorkspaceModule } from '../monitor-location-workspace/monitor-location.module';
 import { StackPipeWorkspaceController } from './stack-pipe.controller';
@@ -11,6 +12,7 @@ import { StackPipeWorkspaceService } from './stack-pipe.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([StackPipeWorkspaceRepository]),
+    EmissionEvaluationModule,
     HttpModule,
     forwardRef(() => MonitorLocationWorkspaceModule),
   ],

--- a/src/stack-pipe-workspace/stack-pipe.service.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.ts
@@ -154,7 +154,7 @@ export class StackPipeWorkspaceService {
       new Date(location.retireDate) < new Date(location.activeDate)
     ) {
       errorList.push(
-        'The Retire Date of the Stack Pipe cannot be before the Active Date',
+        'The Retire Date of the Stack/Pipe cannot be before the Active Date',
       );
     }
 
@@ -168,8 +168,19 @@ export class StackPipeWorkspaceService {
     );
 
     if (
+      stackPipeRecord &&
+      new Date(stackPipeRecord.activeDate).getTime() !==
+        new Date(location.activeDate).getTime()
+    ) {
+      errorList.push(
+        'The Active Date for one or more Stack/Pipe records does not match the official record for this Stack/Pipe. Please contact ECMPS Support if you need to correct the Active Date for any Stack/Pipe records.',
+      );
+    }
+
+    if (
       stackPipeRecord?.retireDate &&
-      stackPipeRecord.retireDate !== location.retireDate
+      new Date(stackPipeRecord.retireDate).getTime() !==
+        new Date(location.retireDate).getTime()
     ) {
       errorList.push('Cannot update a retired stack pipe');
     }
@@ -181,20 +192,15 @@ export class StackPipeWorkspaceService {
 
     if (evaluation) {
       if (
+        stackPipeRecord &&
+        !stackPipeRecord.retireDate &&
         location.retireDate &&
         new Date(location.retireDate) <
           new Date(evaluation.reportingPeriod.endDate)
       ) {
+        // Check the retire date if the record exists.
         errorList.push(
           'The Retire Date of the Stack/Pipe cannot be before the end date of the last Emission Evaluation for the Stack/Pipe.',
-        );
-      } else if (
-        location.activeDate &&
-        new Date(location.activeDate) <=
-          new Date(evaluation.reportingPeriod.endDate)
-      ) {
-        errorList.push(
-          'The Active Date for one or more Stack/Pipe records does not match the last official submission record for this monitoring plan. Please contact ECMPS Support if you need to correct the Active Date for any Stack/Pipe records.',
         );
       }
     }

--- a/src/stack-pipe-workspace/stack-pipe.service.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.ts
@@ -96,6 +96,7 @@ export class StackPipeWorkspaceService {
             trx,
           ),
           stackPipe.retireDate,
+          userId,
           trx,
         )) ??
         (await this.createStackPipeRecord(
@@ -204,15 +205,25 @@ export class StackPipeWorkspaceService {
   async updateStackPipe(
     stackPipeRecord: StackPipe,
     retireDate: Date,
+    userId: string,
     trx?: EntityManager,
   ) {
     if (!stackPipeRecord) return null;
 
     const repository = withTransaction(this.repository, trx);
-    await repository.update(stackPipeRecord.id, {
-      retireDate,
-    });
-    this.logger.debug(`Updated stack pipe ${stackPipeRecord.name}`);
+    if (
+      new Date(retireDate).getTime() !==
+      new Date(stackPipeRecord.retireDate).getTime()
+    ) {
+      await repository.update(stackPipeRecord.id, {
+        retireDate,
+        updateDate: currentDateTime(),
+        userId,
+      });
+      this.logger.debug(`Stack pipe ${stackPipeRecord.name} updated`);
+    } else {
+      this.logger.debug(`Stack pipe ${stackPipeRecord.name} unchanged`);
+    }
     return repository.findOneBy({ id: stackPipeRecord.id });
   }
 }

--- a/src/stack-pipe-workspace/stack-pipe.service.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.ts
@@ -195,8 +195,9 @@ export class StackPipeWorkspaceService {
 
         if (
           stackPipeRecord?.retireDate &&
-          new Date(stackPipeRecord.retireDate).getTime() !==
-            new Date(location.retireDate).getTime()
+          (!location.retireDate ||
+            new Date(stackPipeRecord.retireDate).getTime() !==
+              new Date(location.retireDate).getTime())
         ) {
           errorList.push('Cannot update a retired stack pipe');
         }

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration-checks.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration-checks.service.ts
@@ -37,7 +37,9 @@ export class UnitStackConfigurationChecksService {
 
     if (
       uscRecord?.endDate &&
-      new Date(usc.endDate).getTime() !== new Date(uscRecord.endDate).getTime()
+      (!usc.endDate ||
+        new Date(usc.endDate).getTime() !==
+          new Date(uscRecord.endDate).getTime())
     ) {
       console.log(
         `record end date: ${uscRecord.endDate}, usc end date: ${usc.endDate}`,

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration-checks.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration-checks.service.ts
@@ -29,6 +29,12 @@ export class UnitStackConfigurationChecksService {
       },
     });
 
+    if (usc.endDate && new Date(usc.endDate) < new Date(usc.beginDate)) {
+      errorList.push(
+        `The End Date of the Unit Stack Configuration cannot be before the Begin Date`,
+      );
+    }
+
     if (uscRecord?.endDate && usc.endDate !== uscRecord.endDate) {
       console.log(
         `record end date: ${uscRecord.endDate}, usc end date: ${usc.endDate}`,
@@ -53,27 +59,18 @@ export class UnitStackConfigurationChecksService {
       if (!evaluation) return;
 
       if (
-        uscRecord &&
-        !uscRecord.endDate &&
         usc.endDate &&
         new Date(usc.endDate) < new Date(evaluation.reportingPeriod.endDate)
       ) {
-        // Check the end date if the record exists.
         errorList.push(
-          `The End Date of the Unit Stack Configuration cannot be before the end date of the last Emission Evaluation for the Unit or Stack/Pipe`,
+          'The End Date of the Unit Stack Configuration cannot be before the end date of the last Emission Evaluation for the Unit or Stack/Pipe.',
         );
-      } else if (!uscRecord) {
-        // Check the begin date if the record does not yet exist.
-        if (!usc.beginDate) {
-          errorList.push(`The Unit Stack Configuration must have a Begin Date`);
-        } else if (
-          new Date(usc.beginDate) <=
-          new Date(evaluation.reportingPeriod.endDate)
-        ) {
-          errorList.push(
-            `The Begin Date of the Unit Stack Configuration cannot be on or before the end date of the last Emission Evaluation for the Unit or Stack/Pipe`,
-          );
-        }
+      } else if (
+        new Date(usc.beginDate) <= new Date(evaluation.reportingPeriod.endDate)
+      ) {
+        errorList.push(
+          'The Begin Date for one or more Unit Stack Configuration records does not match the last official submission record for this monitoring plan. Please contact ECMPS Support if you need to correct the Begin Date for any Unit Stack Configuration records.',
+        );
       }
     });
 

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration-checks.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration-checks.service.ts
@@ -35,7 +35,10 @@ export class UnitStackConfigurationChecksService {
       );
     }
 
-    if (uscRecord?.endDate && usc.endDate !== uscRecord.endDate) {
+    if (
+      uscRecord?.endDate &&
+      new Date(usc.endDate).getTime() !== new Date(uscRecord.endDate).getTime()
+    ) {
       console.log(
         `record end date: ${uscRecord.endDate}, usc end date: ${usc.endDate}`,
       );
@@ -59,15 +62,20 @@ export class UnitStackConfigurationChecksService {
       if (!evaluation) return;
 
       if (
+        uscRecord &&
+        !uscRecord.endDate &&
         usc.endDate &&
         new Date(usc.endDate) < new Date(evaluation.reportingPeriod.endDate)
       ) {
+        // Check the end date if the record exists.
         errorList.push(
           'The End Date of the Unit Stack Configuration cannot be before the end date of the last Emission Evaluation for the Unit or Stack/Pipe.',
         );
       } else if (
+        !uscRecord &&
         new Date(usc.beginDate) <= new Date(evaluation.reportingPeriod.endDate)
       ) {
+        // Check the begin date if the record does not yet exist.
         errorList.push(
           'The Begin Date for one or more Unit Stack Configuration records does not match the last official submission record for this monitoring plan. Please contact ECMPS Support if you need to correct the Begin Date for any Unit Stack Configuration records.',
         );

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -60,6 +60,22 @@ export class UnitStackConfigurationWorkspaceService {
   runUnitStackChecks(monitorPlan: UpdateMonitorPlanDTO): string[] {
     const errorList: string[] = [];
 
+    // Check for duplicate unit stack configurations.
+    monitorPlan.unitStackConfigurationData.forEach((usc1, i) => {
+      if (
+        monitorPlan.unitStackConfigurationData.findIndex(
+          usc2 =>
+            usc1.unitId === usc2.unitId &&
+            usc1.stackPipeId === usc2.stackPipeId &&
+            usc1.beginDate === usc2.beginDate,
+        ) !== i
+      ) {
+        errorList.push(
+          `[MONLOC-107-B] Duplicate Unit Stack Configuration record found at index #${i}.`,
+        );
+      }
+    });
+
     const unitStackIds: Set<string> = new Set<string>(); // Set for faster look up times
     const unitUnitIds: Set<string> = new Set<string>();
 

--- a/src/unit/unit.service.ts
+++ b/src/unit/unit.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 
 import { UpdateMonitorLocationDTO } from '../dtos/monitor-location-update.dto';
 import { Unit } from '../entities/unit.entity';
@@ -43,11 +44,22 @@ export class UnitService {
     return errorList;
   }
 
-  async importUnit(unitRecord: Unit, nonLoadI: number, trx?: EntityManager) {
-    await withTransaction(this.repository, trx).update(unitRecord.id, {
-      nonLoadBasedIndicator: nonLoadI,
-    });
-    this.logger.debug(`Imported unit ${unitRecord.name}`);
+  async importUnit(
+    unitRecord: Unit,
+    nonLoadI: number,
+    userId: string,
+    trx?: EntityManager,
+  ) {
+    if (nonLoadI !== unitRecord.nonLoadBasedIndicator) {
+      await withTransaction(this.repository, trx).update(unitRecord.id, {
+        nonLoadBasedIndicator: nonLoadI,
+        updateDate: currentDateTime(),
+        userId,
+      });
+      this.logger.debug(`Unit ${unitRecord.name} updated`);
+    } else {
+      this.logger.debug(`Unit ${unitRecord.name} unchanged`);
+    }
     return true;
   }
 

--- a/src/user-check-out/user-check-out.service.ts
+++ b/src/user-check-out/user-check-out.service.ts
@@ -4,6 +4,7 @@ import { EntityManager } from 'typeorm';
 
 import { UserCheckOutDTO } from '../dtos/user-check-out.dto';
 import { UserCheckOutMap } from '../maps/user-check-out.map';
+import { withTransaction } from '../utils';
 import { UserCheckOutRepository } from './user-check-out.repository';
 
 @Injectable()
@@ -59,8 +60,11 @@ export class UserCheckOutService {
     return this.map.one(record);
   }
 
-  private async ensureNoEvaluationOrSubmissionInProgress(monPlanId: string) {
-    const evalRecordsInProgress = await this.returnManager().query(
+  private async ensureNoEvaluationOrSubmissionInProgress(
+    monPlanId: string,
+    trx?: EntityManager,
+  ) {
+    const evalRecordsInProgress = await (trx ?? this.returnManager()).query(
       `SELECT * FROM CAMDECMPSAUX.evaluation_set es
       JOIN CAMDECMPSAUX.evaluation_queue eq USING(evaluation_set_id)
       WHERE mon_plan_id = $1 AND status_cd NOT IN ('COMPLETE', 'ERROR');
@@ -68,7 +72,9 @@ export class UserCheckOutService {
       [monPlanId],
     );
 
-    const submissionRecordsInProgress = await this.returnManager().query(
+    const submissionRecordsInProgress = await (
+      trx ?? this.returnManager()
+    ).query(
       `SELECT * FROM CAMDECMPSAUX.submission_set
        WHERE mon_plan_id = $1 AND status_cd NOT IN ('COMPLETE', 'ERROR');
       `,
@@ -107,8 +113,13 @@ export class UserCheckOutService {
     return this.entityManager;
   };
 
-  async checkInConfiguration(monPlanId: string): Promise<Boolean> {
-    if (!(await this.ensureNoEvaluationOrSubmissionInProgress(monPlanId))) {
+  async checkInConfiguration(
+    monPlanId: string,
+    trx?: EntityManager,
+  ): Promise<Boolean> {
+    if (
+      !(await this.ensureNoEvaluationOrSubmissionInProgress(monPlanId, trx))
+    ) {
       throw new EaseyException(
         new Error(
           'Record can not be checked in. It is currently being evaluated or submitted.',
@@ -118,7 +129,9 @@ export class UserCheckOutService {
       );
     }
 
-    const result = await this.repository.delete({ monPlanId });
+    const result = await withTransaction(this.repository, trx).delete({
+      monPlanId,
+    });
     return result.affected !== 0;
   }
 }

--- a/src/user-check-out/user-check-out.service.ts
+++ b/src/user-check-out/user-check-out.service.ts
@@ -116,7 +116,7 @@ export class UserCheckOutService {
   async checkInConfiguration(
     monPlanId: string,
     trx?: EntityManager,
-  ): Promise<Boolean> {
+  ): Promise<boolean> {
     if (
       !(await this.ensureNoEvaluationOrSubmissionInProgress(monPlanId, trx))
     ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,10 +1204,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@^17.7.0":
-  version "17.7.1"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.7.1/af5a1dce13fbd6acc490a79aff5ffba54078cfe5#af5a1dce13fbd6acc490a79aff5ffba54078cfe5"
-  integrity sha512-KA7MY/OIYFyxkFuUCOeLgjsgHn1pVyU21fq0eLb+b7erGlLDzpKexHcxwFBDYS+gwQNPjZ/wN6226m4rn/UAgQ==
+"@us-epa-camd/easey-common@^17.7.2":
+  version "17.7.2"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.7.2/40f9f765a640374bc2fa0c8f1610d3a7ce6da3ad#40f9f765a640374bc2fa0c8f1610d3a7ce6da3ad"
+  integrity sha512-q6CqFe8BDTaPR86e3RXHtreM9Z82Fp0TWrvxfFYO7jbm3l8w7KR9sr2bqwZnYfvyA9d4ZZIYZVNxQzvl+dDrXg==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"
@@ -1217,7 +1217,7 @@
     "@nestjs/swagger" "^5.1.2"
     class-validator "^0.14.0"
     dotenv "^10.0.0"
-    express "^4.19.2"
+    express "^4.20.0"
     helmet "^4.6.0"
     json2csv "^5.0.6"
     pg "^8.11.5"
@@ -2878,7 +2878,7 @@ express@4.18.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^4.19.2, express@^4.20.0:
+express@^4.20.0:
   version "4.20.0"
   resolved "https://registry.yarnpkg.com/express/-/express-4.20.0.tgz#f1d08e591fcec770c07be4767af8eb9bcfd67c48"
   integrity sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==


### PR DESCRIPTION
## Related Issues:

- [#5995](https://github.com/US-EPA-CAMD/easey-ui/issues/5995)

## Main Changes:

- Switched to passing the Oris Code rather than the Facility ID in several places to fix roles guard issues.
- Added Stack/Pipe import checks.
- Added Unit Stack Configuration import checks.
- Added logic to check in a Monitoring Plan if reverting it to official causes it to be deleted from the workspace.
- Added logic to update the `updateDate` and `userId` fields in several imports (if changes occurred).