### PR TITLE
Feature/6425 configuration manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@nestjs/typeorm": "^8.0.3",
     "@nestjs/websockets": "^8.4.7",
     "@types/pg": "^8.6.4",
-    "@us-epa-camd/easey-common": "^17.7.0",
+    "@us-epa-camd/easey-common": "^17.7.2",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",
     "dotenv": "^10.0.0",

--- a/src/monitor-plan-reporting-freq-workspace/monitor-plan-reporting-freq.repository.ts
+++ b/src/monitor-plan-reporting-freq-workspace/monitor-plan-reporting-freq.repository.ts
@@ -34,7 +34,6 @@ export class MonitorPlanReportingFrequencyWorkspaceRepository extends Repository
       reportFrequencyCode,
       userId,
       addDate: currentDateTime(),
-      updateDate: currentDateTime(),
     });
 
     return await this.save(record);

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -98,6 +98,8 @@ export class MonitorPlanWorkspaceController {
   @RoleGuard(
     {
       bodyParam: 'orisCode',
+      requiredRoles: ['Preparer', 'Submitter', 'Sponsor', 'Initial Authorizer'],
+      permissionsForFacility: ['DSMP'],
     },
     LookupType.Facility,
   )

--- a/src/monitor-plan-workspace/monitor-plan.repository.ts
+++ b/src/monitor-plan-workspace/monitor-plan.repository.ts
@@ -27,7 +27,6 @@ export class MonitorPlanWorkspaceRepository extends Repository<MonitorPlan> {
       lastUpdated: currentDateTime(),
       needsEvalFlag: 'Y',
       submissionAvailabilityCode: 'GRANTED',
-      updateDate: currentDateTime(),
       updatedStatusFlag: 'Y',
       userId,
     });

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -213,6 +213,7 @@ export class MonitorPlanWorkspaceService {
         beginReportPeriod: methodBeginReportingPeriod.periodAbbreviation,
       });
       firstPlanRecord.beginReportPeriodId = methodBeginReportingPeriod.id;
+      firstPlanRecord.updateDate = currentDateTime();
       const repository = withTransaction(this.repository, trx);
       await repository.save(firstPlanRecord);
       await repository.resetToNeedsEvaluation(firstPlanRecord.id, userId);

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -1389,7 +1389,7 @@ export class MonitorPlanWorkspaceService {
         planEndReportPeriodId,
       )) ??
       (planEndReportPeriodId !== null
-        ? await this.matchToPlanByLocationsAndBeginPeriod(
+        ? await this.matchToPlanByLocationsAndEndPeriod(
             locationIds,
             existingPlans,
             null,

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -1200,12 +1200,42 @@ export class MonitorPlanWorkspaceService {
     existingPlans: MonitorPlanWorkspace[],
     beginReportPeriodId: number,
   ) {
+    return this.matchToPlanByLocationsAndPeriod(
+      locationIds,
+      existingPlans,
+      beginReportPeriodId,
+      'begin',
+    );
+  }
+
+  private async matchToPlanByLocationsAndEndPeriod(
+    locationIds: { unitIds: Set<string>; stackPipeIds: Set<string> },
+    existingPlans: MonitorPlanWorkspace[],
+    endReportPeriodId: number | null,
+  ) {
+    return this.matchToPlanByLocationsAndPeriod(
+      locationIds,
+      existingPlans,
+      endReportPeriodId,
+      'end',
+    );
+  }
+
+  private async matchToPlanByLocationsAndPeriod(
+    locationIds: { unitIds: Set<string>; stackPipeIds: Set<string> },
+    existingPlans: MonitorPlanWorkspace[],
+    periodId: number | null,
+    periodType: 'begin' | 'end',
+  ) {
     const locationIdsString = Array.from(locationIds.unitIds)
       .concat(Array.from(locationIds.stackPipeIds))
       .sort((a, b) => a.localeCompare(b))
       .join(',');
-    const matchedPlan = existingPlans.find(plan => {
-      if (plan.beginReportPeriodId !== beginReportPeriodId) return false;
+    const matchPlan = (plan: MonitorPlanWorkspace) => {
+      if (periodType === 'begin' && plan.beginReportPeriodId !== periodId)
+        return false;
+      if (periodType === 'end' && plan.endReportPeriodId !== periodId)
+        return false;
 
       const planLocationIdsString = plan.locations
         .map(l => l.unit?.name ?? l.stackPipe?.name)
@@ -1215,9 +1245,22 @@ export class MonitorPlanWorkspaceService {
       if (locationIdsString !== planLocationIdsString) return false;
 
       return true;
-    });
+    };
 
+    const firstMatch = existingPlans.find(matchPlan);
+    const lastMatch = [...existingPlans].reverse().find(matchPlan);
+
+    const matchedPlan = firstMatch;
     if (!matchedPlan) return null;
+
+    if (firstMatch !== lastMatch) {
+      throw new EaseyException(
+        new Error(
+          'The calculated monitor plan matched multiple existing monitor plans',
+        ),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
 
     return this.getMonitorPlan(matchedPlan.id, { full: true });
   }
@@ -1306,6 +1349,80 @@ export class MonitorPlanWorkspaceService {
     throwIfErrors(errorList);
   }
 
+  private async syncLegacyMonitorPlan({
+    existingPlans,
+    trx,
+    userId,
+    workingPlan,
+  }: {
+    existingPlans: MonitorPlanWorkspace[];
+    trx: EntityManager;
+    userId: string;
+    workingPlan: WorkingConfiguration;
+  }) {
+    if (workingPlan.endYear && workingPlan.endYear < 2009) {
+      // Plans with end years before 2009 existed before ECMPS 1.0 was fully implemented, leave them alone.
+      return {
+        status: 'unchanged',
+        plan: null,
+      };
+    }
+
+    const planEndReportPeriodId =
+      workingPlan.endYear && workingPlan.endQuarter
+        ? (
+            await this.reportingPeriodRepository.getByYearQuarter(
+              workingPlan.endYear,
+              workingPlan.endQuarter,
+            )
+          ).id
+        : null;
+
+    // Get the monitoring locations associated with the working plan.
+    const locationIds = this.getItemLocationIds(workingPlan.items);
+
+    // Match the working plan to an existing monitor plan by locations and end period.
+    const matchedPlan =
+      (await this.matchToPlanByLocationsAndEndPeriod(
+        locationIds,
+        existingPlans,
+        planEndReportPeriodId,
+      )) ??
+      (planEndReportPeriodId !== null
+        ? await this.matchToPlanByLocationsAndBeginPeriod(
+            locationIds,
+            existingPlans,
+            null,
+          )
+        : null);
+
+    if (matchedPlan) {
+      if (!matchedPlan.endReportPeriodId && planEndReportPeriodId) {
+        return {
+          status: 'ended',
+          plan: await this.updateEndReportingPeriod(
+            matchedPlan,
+            planEndReportPeriodId,
+            userId,
+            trx,
+          ),
+        };
+      } else {
+        return {
+          status: 'unchanged',
+          plan: null,
+        };
+      }
+    } else {
+      throw new EaseyException(
+        new Error(
+          'Cannot create a new monitor plan with a begin period before 2009',
+        ),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
   private async syncMonitorPlan({
     existingPlans,
     facilityId,
@@ -1321,6 +1438,15 @@ export class MonitorPlanWorkspaceService {
     userId: string;
     workingPlan: WorkingConfiguration;
   }) {
+    if (workingPlan.beginYear < 2009) {
+      return this.syncLegacyMonitorPlan({
+        existingPlans,
+        trx,
+        userId,
+        workingPlan,
+      });
+    }
+
     // Calculate the report period range from the working monitor plan.
     const planBeginReportPeriodId = (
       await this.reportingPeriodRepository.getByYearQuarter(
@@ -1362,7 +1488,7 @@ export class MonitorPlanWorkspaceService {
       } else {
         return {
           status: 'unchanged',
-          plan: matchedPlan,
+          plan: null,
         };
       }
     } else {

--- a/src/stack-pipe-workspace/stack-pipe.controller.ts
+++ b/src/stack-pipe-workspace/stack-pipe.controller.ts
@@ -20,9 +20,9 @@ export class StackPipeWorkspaceController {
   })
   @RoleGuard(
     {
-      enforceCheckout: false,
       bodyParam: 'facilityId',
-      enforceEvalSubmitCheck: false,
+      requiredRoles: ['Preparer', 'Submitter', 'Sponsor', 'Initial Authorizer'],
+      permissionsForFacility: ['DSMP'],
     },
     LookupType.Facility,
   )

--- a/src/stack-pipe-workspace/stack-pipe.service.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.ts
@@ -53,7 +53,6 @@ export class StackPipeWorkspaceService {
       retireDate: loc.retireDate,
       userId,
       addDate: currentDateTime(),
-      updateDate: currentDateTime(),
     });
 
     return await repository.save(stackPipe);

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -192,7 +192,6 @@ export class UnitStackConfigurationWorkspaceService {
       beginDate: payload.beginDate,
       endDate: payload.endDate,
       addDate: currentDateTime(),
-      updateDate: currentDateTime(),
       userId,
     });
 


### PR DESCRIPTION
## Related Issues:

- [#6425](https://github.com/US-EPA-CAMD/easey-ui/issues/6425)

## Main Changes:

- Removed some instances of setting the `updateDate` on a row when it should not be set.
- Addressed pre-2009 monitor plan cases.
- Added missing `RolesGuard` configuration.

## TODO:

- [ ] Make sure the related [`easey-common`](https://github.com/US-EPA-CAMD/easey-common/pull/176) PR is merged in first, so the updated package version is picked up when this is merged.