### PR TITLE
fix:remove workspace api from swagger beta env

### DIFF
--- a/src/analyzer-range-workspace/analyzer-range.controller.ts
+++ b/src/analyzer-range-workspace/analyzer-range.controller.ts
@@ -10,6 +10,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { AnalyzerRangeWorkspaceService } from './analyzer-range.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { AnalyzerRangeChecksService } from './analyzer-range-checks.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -26,6 +27,7 @@ export class AnalyzerRangeWorkspaceController {
     type: AnalyzerRangeDTO,
     description: 'Retrieves workspace Analyzer Range records for a component',
   })
+  @ApiExcludeEndpointByEnv()
   @RoleGuard(
     {
       enforceCheckout: false,
@@ -42,6 +44,7 @@ export class AnalyzerRangeWorkspaceController {
   }
 
   @Post()
+  @ApiExcludeEndpointByEnv()
   @RoleGuard(
     {
       pathParam: 'locId',
@@ -71,6 +74,7 @@ export class AnalyzerRangeWorkspaceController {
   }
 
   @Put(':analyzerRangeId')
+  @ApiExcludeEndpointByEnv()
   @RoleGuard(
     {
       pathParam: 'locId',

--- a/src/check-out/check-out.controller.ts
+++ b/src/check-out/check-out.controller.ts
@@ -10,6 +10,7 @@ import {
 import { UserCheckOutService } from '../user-check-out/user-check-out.service';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -36,6 +37,7 @@ export class CheckOutController {
     { pathParam: 'planId', enforceCheckout: false },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: UserCheckOutBaseDTO,
     description: 'Checks Out a Monitor Plan configuration',
@@ -57,6 +59,7 @@ export class CheckOutController {
     { pathParam: 'planId', enforceCheckout: false },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: UserCheckOutBaseDTO,
     description: 'Updates last activity for a checked out Monitor Plan',
@@ -76,6 +79,7 @@ export class CheckOutController {
     { pathParam: 'planId', enforceCheckout: false },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Check-In a Monitor Plan configuration',
   })

--- a/src/check-out/check-out.controller.ts
+++ b/src/check-out/check-out.controller.ts
@@ -28,6 +28,7 @@ export class CheckOutController {
     description:
       'Retrieves workspace Monitor Plan configuration records that are checked out by users',
   })
+  @ApiExcludeEndpointByEnv()
   getCheckedOutConfigurations(): Promise<UserCheckOutDTO[]> {
     return this.ucoService.getCheckedOutConfigurations();
   }

--- a/src/component-workspace/component.controller.ts
+++ b/src/component-workspace/component.controller.ts
@@ -7,6 +7,7 @@ import { RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { ComponentCheckService } from './component-checks.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -31,6 +32,7 @@ export class ComponentWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getComponents(@Param('locId') locationId: string): Promise<ComponentDTO[]> {
     return this.service.getComponents(locationId);
   }
@@ -44,6 +46,7 @@ export class ComponentWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: ComponentDTO,

--- a/src/duct-waf-workspace/duct-waf.controller.ts
+++ b/src/duct-waf-workspace/duct-waf.controller.ts
@@ -6,6 +6,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 
 import { DuctWafBaseDTO, DuctWafDTO } from '../dtos/duct-waf.dto';
 import { DuctWafWorkspaceService } from './duct-waf.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -27,6 +28,7 @@ export class DuctWafWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getDuctWafs(@Param('locId') locationId: string): Promise<DuctWafDTO[]> {
     return this.service.getDuctWafs(locationId);
   }
@@ -40,6 +42,7 @@ export class DuctWafWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: DuctWafDTO,
     description: 'Create a workspace duct waf record for a monitor location',
@@ -65,6 +68,7 @@ export class DuctWafWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: DuctWafDTO,
     description: 'Updates a workspace duct waf record for a monitor location',

--- a/src/lee-qualification-workspace/lee-qualification.controller.ts
+++ b/src/lee-qualification-workspace/lee-qualification.controller.ts
@@ -9,6 +9,7 @@ import {
   LEEQualificationDTO,
 } from '../dtos/lee-qualification.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -31,6 +32,7 @@ export class LEEQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getLEEQualifications(
     @Param('locId') locId: string,
     @Param('qualId') qualId: string,
@@ -47,6 +49,7 @@ export class LEEQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: LEEQualificationDTO,
     description:
@@ -77,6 +80,7 @@ export class LEEQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: LEEQualificationDTO,

--- a/src/lme-qualification-workspace/lme-qualification.controller.ts
+++ b/src/lme-qualification-workspace/lme-qualification.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '../dtos/lme-qualification.dto';
 import { LMEQualificationWorkspaceService } from './lme-qualification.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -31,6 +32,7 @@ export class LMEQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getLMEQualifications(
     @Param('locId') locationId: string,
     @Param('qualId') qualificationId: string,
@@ -47,6 +49,7 @@ export class LMEQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: LMEQualificationDTO,
     description:
@@ -77,6 +80,7 @@ export class LMEQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: LMEQualificationDTO,

--- a/src/mats-method-workspace/mats-method.controller.ts
+++ b/src/mats-method-workspace/mats-method.controller.ts
@@ -7,6 +7,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { MatsMethodBaseDTO, MatsMethodDTO } from '../dtos/mats-method.dto';
 import { MatsMethodChecksService } from './mats-method-checks.service';
 import { MatsMethodWorkspaceService } from './mats-method.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -32,6 +33,7 @@ export class MatsMethodWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getMethods(@Param('locId') locationId: string): Promise<MatsMethodDTO[]> {
     return this.service.getMethods(locationId);
   }
@@ -45,6 +47,7 @@ export class MatsMethodWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MatsMethodDTO,
     description: 'Creates workspace MATS Method record',
@@ -71,6 +74,7 @@ export class MatsMethodWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MatsMethodDTO,
     description: 'Updates workspace MATS Method record',

--- a/src/monitor-attribute-workspace/monitor-attribute.controller.ts
+++ b/src/monitor-attribute-workspace/monitor-attribute.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '../dtos/monitor-attribute.dto';
 import { MonitorAttributeWorkspaceService } from './monitor-attribute.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -30,6 +31,7 @@ export class MonitorAttributeWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getAttributes(
     @Param('locId') locationId: string,
   ): Promise<MonitorAttributeDTO[]> {
@@ -45,6 +47,7 @@ export class MonitorAttributeWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorAttributeDTO,
     description: 'Creates a workspace monitor location attribute record',
@@ -70,6 +73,7 @@ export class MonitorAttributeWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorAttributeDTO,
     description: 'Updates a workspace monitor location attribute record',

--- a/src/monitor-configurations-workspace/monitor-configurations-workspace.controller.ts
+++ b/src/monitor-configurations-workspace/monitor-configurations-workspace.controller.ts
@@ -6,6 +6,7 @@ import { ConfigurationMultipleParamsDTO } from '../dtos/configuration-multiple-p
 
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
 import { MonitorConfigurationsWorkspaceService } from './monitor-configurations-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -39,6 +40,7 @@ export class MonitorConfigurationsWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   getConfigurations(
     @Query() dto: ConfigurationMultipleParamsDTO,
   ): Promise<MonitorPlanDTO[]> {

--- a/src/monitor-default-workspace/monitor-default.controller.ts
+++ b/src/monitor-default-workspace/monitor-default.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '../dtos/monitor-default.dto';
 import { MonitorDefaultWorkspaceService } from './monitor-default.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -25,6 +26,7 @@ export class MonitorDefaultWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: MonitorDefaultDTO,
@@ -45,6 +47,7 @@ export class MonitorDefaultWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorDefaultDTO,
     description: 'Updates a workspace default record for a monitor location',
@@ -72,6 +75,7 @@ export class MonitorDefaultWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorDefaultDTO,
     description: 'Creates a workspace defaults record for a monitor location',

--- a/src/monitor-formula-workspace/monitor-formula.controller.ts
+++ b/src/monitor-formula-workspace/monitor-formula.controller.ts
@@ -10,6 +10,7 @@ import {
   MonitorFormulaDTO,
 } from '../dtos/monitor-formula.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -29,6 +30,7 @@ export class MonitorFormulaWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: MonitorFormulaDTO,
@@ -49,6 +51,7 @@ export class MonitorFormulaWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorFormulaDTO,
     description: 'Creates workspace formula record for a monitor location',
@@ -75,6 +78,7 @@ export class MonitorFormulaWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorFormulaDTO,
     description: 'Updates workspace formula record for a monitor location',

--- a/src/monitor-load-workspace/monitor-load.controller.ts
+++ b/src/monitor-load-workspace/monitor-load.controller.ts
@@ -6,6 +6,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { MonitorLoadWorkspaceService } from './monitor-load.service';
 import { MonitorLoadBaseDTO, MonitorLoadDTO } from '../dtos/monitor-load.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -22,6 +23,7 @@ export class MonitorLoadWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: MonitorLoadDTO,
@@ -40,6 +42,7 @@ export class MonitorLoadWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorLoadDTO,
     description: 'Updates a workspace load record for a monitor location',
@@ -67,6 +70,7 @@ export class MonitorLoadWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: MonitorLoadDTO,

--- a/src/monitor-location-workspace/monitor-location.controller.ts
+++ b/src/monitor-location-workspace/monitor-location.controller.ts
@@ -4,6 +4,7 @@ import { RoleGuard } from '@us-epa-camd/easey-common/decorators';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { MonitorLocationDTO } from '../dtos/monitor-location.dto';
 import { MonitorLocationWorkspaceService } from './monitor-location.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -26,6 +27,7 @@ export class MonitorLocationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getLocation(@Param('locId') locationId: string): Promise<MonitorLocationDTO> {
     return this.service.getLocation(locationId);
   }
@@ -39,6 +41,7 @@ export class MonitorLocationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getLocationRelationships(@Param('locId') locId: string) {
     return this.service.getLocationRelationships(locId);
   }

--- a/src/monitor-method-workspace/monitor-method.controller.ts
+++ b/src/monitor-method-workspace/monitor-method.controller.ts
@@ -9,6 +9,7 @@ import {
   MonitorMethodDTO,
 } from '../dtos/monitor-method.dto';
 import { MonitorMethodWorkspaceService } from './monitor-method.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -25,6 +26,7 @@ export class MonitorMethodWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: MonitorMethodDTO,
@@ -43,6 +45,7 @@ export class MonitorMethodWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorMethodDTO,
     description: 'Creates workspace Monitor Method record',
@@ -68,6 +71,7 @@ export class MonitorMethodWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorMethodDTO,
     description: 'Updates workspace Monitor Method record',

--- a/src/monitor-plan-comment-workspace/monitor-plan-comment.controller.ts
+++ b/src/monitor-plan-comment-workspace/monitor-plan-comment.controller.ts
@@ -5,6 +5,7 @@ import { MonitorPlanCommentDTO } from '../dtos/monitor-plan-comment.dto';
 import { MonitorPlanCommentWorkspaceService } from './monitor-plan-comment.service';
 import { RoleGuard } from '@us-epa-camd/easey-common/decorators';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -26,6 +27,7 @@ export class MonitorPlanCommentWorkspaceController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   getComments(
     @Param('planId') planId: string,
   ): Promise<MonitorPlanCommentDTO[]> {

--- a/src/monitor-plan-reporting-freq-workspace/monitor-plan-reporting-freq.controller.ts
+++ b/src/monitor-plan-reporting-freq-workspace/monitor-plan-reporting-freq.controller.ts
@@ -5,6 +5,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 
 import { ReportingFreqDTO } from '../dtos/reporting-freq.dto';
 import { MonitorPlanReportingFrequencyWorkspaceService } from './monitor-plan-reporting-freq.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -29,6 +30,7 @@ export class MonitorPlanReportingFrequencyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getReportingFreqs(
     @Param('unitId') unitId: number,
   ): Promise<ReportingFreqDTO[]> {

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -22,6 +22,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { MonitorPlanChecksService } from './monitor-plan-checks.service';
 import { UpdateMonitorPlanDTO } from '../dtos/monitor-plan-update.dto';
 import { MonitorPlanParamsDTO } from '../dtos/monitor-plan-params.dto';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -46,6 +47,7 @@ export class MonitorPlanWorkspaceController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @AuditLog({
     label: 'Export Monitor Plan',
     requestQueryOutFields: ['planId']
@@ -71,6 +73,7 @@ export class MonitorPlanWorkspaceController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   getMonitorPlan(@Param('planId') planId: string): Promise<MonitorPlanDTO> {
     return this.service.getMonitorPlan(planId);
   }
@@ -84,6 +87,7 @@ export class MonitorPlanWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorPlanImportResponseDTO,
     description: 'imports an entire monitor plan from JSON payload',
@@ -109,6 +113,7 @@ export class MonitorPlanWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorPlanDTO,
     description:
@@ -136,6 +141,7 @@ export class MonitorPlanWorkspaceController {
     },
     LookupType.MonitorPlan,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description:
       'Revert workspace monitor plan back to official submitted record',

--- a/src/monitor-qualification-workspace/monitor-qualification.controller.ts
+++ b/src/monitor-qualification-workspace/monitor-qualification.controller.ts
@@ -9,6 +9,7 @@ import {
   MonitorQualificationDTO,
 } from '../dtos/monitor-qualification.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -31,6 +32,7 @@ export class MonitorQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getQualifications(
     @Param('locId') locationId: string,
   ): Promise<MonitorQualificationDTO[]> {
@@ -46,6 +48,7 @@ export class MonitorQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorQualificationDTO,
     description:
@@ -72,6 +75,7 @@ export class MonitorQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorQualificationDTO,
     description:

--- a/src/monitor-span-workspace/monitor-span.controller.ts
+++ b/src/monitor-span-workspace/monitor-span.controller.ts
@@ -7,6 +7,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { MonitorSpanWorkspaceService } from './monitor-span.service';
 import { MonitorSpanBaseDTO, MonitorSpanDTO } from '../dtos/monitor-span.dto';
 import { MonitorSpanChecksService } from './monitor-span-checks.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -26,6 +27,7 @@ export class MonitorSpanWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: MonitorSpanDTO,
@@ -44,6 +46,7 @@ export class MonitorSpanWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorSpanDTO,
     description: 'Updates a workspace span record for a monitor location',
@@ -72,6 +75,7 @@ export class MonitorSpanWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: MonitorSpanDTO,

--- a/src/monitor-system-workspace/monitor-system.controller.ts
+++ b/src/monitor-system-workspace/monitor-system.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '../dtos/monitor-system.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { MonitorSystemCheckService } from './monitor-system-checks.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiTags('Systems')
@@ -35,6 +36,7 @@ export class MonitorSystemWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getSystems(@Param('locId') locationId: string): Promise<MonitorSystemDTO[]> {
     return this.service.getSystems(locationId);
   }
@@ -48,6 +50,7 @@ export class MonitorSystemWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorSystemDTO,
     description: 'Creates a workspace system record for a give location',
@@ -74,6 +77,7 @@ export class MonitorSystemWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: MonitorSystemDTO,
     description:

--- a/src/pct-qualification-workspace/pct-qualification.controller.ts
+++ b/src/pct-qualification-workspace/pct-qualification.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '../dtos/pct-qualification.dto';
 import { PCTQualificationWorkspaceService } from './pct-qualification.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -31,6 +32,7 @@ export class PCTQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getPCTQualifications(
     @Param('locId') locId: string,
     @Param('qualId') qualId: string,
@@ -47,6 +49,7 @@ export class PCTQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: PCTQualificationDTO,
     description:
@@ -77,6 +80,7 @@ export class PCTQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: PCTQualificationDTO,

--- a/src/stack-pipe-workspace/stack-pipe.controller.ts
+++ b/src/stack-pipe-workspace/stack-pipe.controller.ts
@@ -6,6 +6,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 
 import { StackPipeBaseDTO, StackPipeDTO } from '../dtos/stack-pipe.dto';
 import { StackPipeWorkspaceService } from './stack-pipe.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -26,6 +27,7 @@ export class StackPipeWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   importStackPipe(
     @Query('draft') draft: boolean,
     @Body() stackPipe: StackPipeBaseDTO,

--- a/src/system-component-workspace/system-component.controller.ts
+++ b/src/system-component-workspace/system-component.controller.ts
@@ -10,6 +10,7 @@ import {
 import { SystemComponentWorkspaceService } from './system-component.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { ComponentCheckService } from '../component-workspace/component-checks.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -31,6 +32,7 @@ export class SystemComponentWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getSystemComponents(
     @Param('locId') locationId: string,
     @Param('sysId') monSysId: string,
@@ -47,6 +49,7 @@ export class SystemComponentWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: SystemComponentDTO,
     description: 'Updates workspace component records for a monitor system',
@@ -76,6 +79,7 @@ export class SystemComponentWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: SystemComponentDTO,
     description: 'Creates a workspace system component for a monitor system',

--- a/src/system-fuel-flow-workspace/system-fuel-flow.controller.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '../dtos/system-fuel-flow.dto';
 import { SystemFuelFlowWorkspaceService } from './system-fuel-flow.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -30,6 +31,7 @@ export class SystemFuelFlowWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getFuelFlows(
     @Param('locId') locationId: string,
     @Param('sysId') monSysId: string,
@@ -46,6 +48,7 @@ export class SystemFuelFlowWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: SystemFuelFlowDTO,
     description: 'Creates official fuel flow records for a monitor system',
@@ -73,6 +76,7 @@ export class SystemFuelFlowWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: SystemFuelFlowDTO,
     description:

--- a/src/unit-capacity-workspace/unit-capacity.controller.ts
+++ b/src/unit-capacity-workspace/unit-capacity.controller.ts
@@ -9,6 +9,7 @@ import {
   UnitCapacityDTO,
 } from '../dtos/unit-capacity.dto';
 import { UnitCapacityWorkspaceService } from './unit-capacity.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -31,6 +32,7 @@ export class UnitCapacityWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getUnitCapacities(
     @Param('locId') locationId: string,
     @Param('unitId') unitId: number,
@@ -47,6 +49,7 @@ export class UnitCapacityWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: UnitCapacityDTO,
@@ -75,6 +78,7 @@ export class UnitCapacityWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: UnitCapacityDTO,
     description: 'Updates a workspace unit capacity record by unit capacity ID',

--- a/src/unit-control-workspace/unit-control.controller.ts
+++ b/src/unit-control-workspace/unit-control.controller.ts
@@ -8,6 +8,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { UnitControlBaseDTO, UnitControlDTO } from '../dtos/unit-control.dto';
 import { UnitControlChecksService } from './unit-control-checks.service';
 import { UnitControlWorkspaceService } from './unit-control.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -33,6 +34,7 @@ export class UnitControlWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getUnitControls(
     @Param('locId') locId: string,
     @Param('unitId') unitId: number,
@@ -49,6 +51,7 @@ export class UnitControlWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: UnitControlDTO,
     description: 'Updates a workspace unit control record by unit control ID',
@@ -79,6 +82,7 @@ export class UnitControlWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: UnitControlDTO,

--- a/src/unit-fuel-workspace/unit-fuel.controller.ts
+++ b/src/unit-fuel-workspace/unit-fuel.controller.ts
@@ -6,6 +6,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 
 import { UnitFuelBaseDTO, UnitFuelDTO } from '../dtos/unit-fuel.dto';
 import { UnitFuelWorkspaceService } from './unit-fuel.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -28,6 +29,7 @@ export class UnitFuelWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getUnitFuels(
     @Param('locId') locId: string,
     @Param('unitId') unitId: number,
@@ -44,6 +46,7 @@ export class UnitFuelWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: UnitFuelDTO,
     description: 'Updates a workspace unit control record by unit control ID',
@@ -71,6 +74,7 @@ export class UnitFuelWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: UnitFuelDTO,

--- a/src/unit-program-workspace/unit-program.controller.ts
+++ b/src/unit-program-workspace/unit-program.controller.ts
@@ -5,6 +5,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 
 import { UnitProgramDTO } from '../dtos/unit-program.dto';
 import { UnitProgramWorkspaceService } from './unit-program.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -27,6 +28,7 @@ export class UnitProgramWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getUnitProgramsByUnitRecordId(
     @Param('unitId') unitId: number,
   ): Promise<UnitProgramDTO[]> {

--- a/src/unit-workspace/unit.controller.ts
+++ b/src/unit-workspace/unit.controller.ts
@@ -6,6 +6,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 
 import { UnitWorkspaceService } from './unit.service';
 import { UnitBaseDTO, UnitDTO } from '../dtos/unit.dto';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -28,6 +29,7 @@ export class UnitWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getUnits(
     @Param('locId') locId: string,
     @Param('id') unitId: number,
@@ -44,6 +46,7 @@ export class UnitWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: UnitDTO,
     description: 'Updates a workspace unit record by unit ID',

--- a/src/utilities/swagger-decorator.const.ts
+++ b/src/utilities/swagger-decorator.const.ts
@@ -1,0 +1,14 @@
+import { ApiExcludeEndpoint, ApiExcludeController } from '@nestjs/swagger';
+import { applyDecorators } from '@nestjs/common';
+import { getConfigValue } from '@us-epa-camd/easey-common/utilities';
+
+const env = getConfigValue('EASEY_MONITOR_PLAN_API_ENV', 'local-dev');
+const disable = ['local-dev','development','testing'].includes(env) ? false : true;
+
+export function ApiExcludeControllerByEnv() {
+    return applyDecorators(ApiExcludeController(disable));
+}
+
+export function ApiExcludeEndpointByEnv() {
+    return applyDecorators(ApiExcludeEndpoint(disable));
+}


### PR DESCRIPTION
## Ticket
[Remove monitor-plan-mgmt's workspace API from Swagger page](https://github.com/US-EPA-CAMD/easey-ui/issues/6458)

## Changes

- Create a decorator for exclude APIs end points from swagger page
- Apply created decorated in workspace APIs