### PR TITLE
Update package.json to use tilde for easey-common versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@nestjs/typeorm": "^8.0.3",
     "@nestjs/websockets": "^8.4.7",
     "@types/pg": "^8.6.4",
-    "@us-epa-camd/easey-common": "^17.7.2",
+    "@us-epa-camd/easey-common": "~17.8.2",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
change the versioning for easey-common dependency to use tilde to avoid picking up anything but minor updates