### PR TITLE
Incorrect Error Message for Large Max Fuel Flow Rate Value 

### DIFF
--- a/src/dtos/system-fuel-flow.dto.ts
+++ b/src/dtos/system-fuel-flow.dto.ts
@@ -54,11 +54,7 @@ export class SystemFuelFlowBaseDTO {
     99999999.9,
     {
       message: (args: ValidationArguments) => {
-        return CheckCatalogService.formatResultMessage('FUELFLW-2-B', {
-          value: args.value,
-          fieldname: args.property,
-          key: KEY,
-        });
+        return `The Max Fuel Flow Rate value must be in the range 0 to 99,999,999.9`;
       },
     },
     false,


### PR DESCRIPTION
Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6240

Changes
Updated validation error message for flow rate value. If the value is from 0 to 99999999.9 the right message should be render. 