### PR TITLE
Fix/6425 update rp on method change

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "repl": "nest start --watch --entryFile repl",
     "start": "node dist/main",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/src/analyzer-range-workspace/analyzer-range.service.ts
+++ b/src/analyzer-range-workspace/analyzer-range.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
+import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { EntityManager } from 'typeorm';
 import { v4 as uuid } from 'uuid';
@@ -19,10 +20,13 @@ export class AnalyzerRangeWorkspaceService {
   constructor(
     private readonly repository: AnalyzerRangeWorkspaceRepository,
     private readonly map: AnalyzerRangeMap,
+    private readonly logger: Logger,
 
     @Inject(forwardRef(() => MonitorPlanWorkspaceService))
     private readonly mpService: MonitorPlanWorkspaceService,
-  ) {}
+  ) {
+    this.logger.setContext('AnalyzerRangeWorkspaceService');
+  }
 
   async getAnalyzerRanges(compId: string): Promise<AnalyzerRangeDTO[]> {
     const results = await this.repository.findBy({ componentRecordId: compId });
@@ -130,7 +134,7 @@ export class AnalyzerRangeWorkspaceService {
     analyzerRanges: AnalyzerRangeBaseDTO[] = [],
     trx?: EntityManager,
   ) {
-    return Promise.all(
+    await Promise.all(
       analyzerRanges.map(async analyzerRange => {
         const analyzerRangeRecord = await withTransaction(
           this.repository,
@@ -161,5 +165,7 @@ export class AnalyzerRangeWorkspaceService {
         }
       }),
     );
+    this.logger.debug(`Imported ${analyzerRanges.length} analyzer ranges`);
+    return true;
   }
 }

--- a/src/component-workspace/component.controller.ts
+++ b/src/component-workspace/component.controller.ts
@@ -3,7 +3,11 @@ import { Get, Param, Controller, Post, Body, Put } from '@nestjs/common';
 
 import { ComponentDTO, UpdateComponentBaseDTO } from '../dtos/component.dto';
 import { ComponentWorkspaceService } from './component.service';
-import { AuditLog, RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
+import {
+  AuditLog,
+  RoleGuard,
+  User,
+} from '@us-epa-camd/easey-common/decorators';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { ComponentCheckService } from './component-checks.service';
@@ -41,7 +45,7 @@ export class ComponentWorkspaceController {
   )
   @AuditLog({
     label: 'Retrieved workspace monitor location components',
-    requestParamsOutFields: ['locId']
+    requestParamsOutFields: ['locId'],
   })
   getComponents(@Param('locId') locationId: string): Promise<ComponentDTO[]> {
     return this.service.getComponents(locationId);
@@ -59,7 +63,7 @@ export class ComponentWorkspaceController {
   @AuditLog({
     label: 'Created workspace monitor location component record',
     requestParamsOutFields: ['locId'],
-    responseBodyOutFields: '*'
+    responseBodyOutFields: '*',
   })
   @ApiOkResponse({
     isArray: true,
@@ -72,7 +76,11 @@ export class ComponentWorkspaceController {
     @User() user: CurrentUser,
   ): Promise<ComponentDTO> {
     await this.checkService.runChecks(locId, payload, false, true);
-    return this.service.createComponent(locId, payload, user.userId);
+    return this.service.createComponent({
+      locationId: locId,
+      payload,
+      userId: user.userId,
+    });
   }
 
   @Put(':compId')

--- a/src/component-workspace/component.service.spec.ts
+++ b/src/component-workspace/component.service.spec.ts
@@ -278,11 +278,11 @@ describe('ComponentWorkspaceService', () => {
 
   describe('createComponent', () => {
     it('should create and return a component dto', async () => {
-      const response = await service.createComponent(
+      const response = await service.createComponent({
         locationId,
         payload,
         userId,
-      );
+      });
       expect(response).toEqual(componentDto);
     });
   });

--- a/src/component-workspace/component.service.ts
+++ b/src/component-workspace/component.service.ts
@@ -136,7 +136,7 @@ export class ComponentWorkspaceService {
         if (!compRecord) {
           // Check used_identifier table to see if the componentId has already
           // been used, and if so grab that component record for update
-          let usedIdentifier = await withTransaction(
+          const usedIdentifier = await withTransaction(
             this.usedIdRepo,
             trx,
           ).getBySpecs(locationId, component.componentId, 'C');
@@ -163,13 +163,15 @@ export class ComponentWorkspaceService {
           );
         }
 
-        await this.analyzerRangeDataService.importAnalyzerRange(
-          compRecord.id,
-          locationId,
-          userId,
-          component.analyzerRangeData,
-          trx,
-        );
+        if ((component.analyzerRangeData ?? []).length > 0) {
+          await this.analyzerRangeDataService.importAnalyzerRange(
+            compRecord.id,
+            locationId,
+            userId,
+            component.analyzerRangeData,
+            trx,
+          );
+        }
       }),
     );
     this.logger.debug(`Imported ${location.componentData.length} components`);

--- a/src/component-workspace/component.service.ts
+++ b/src/component-workspace/component.service.ts
@@ -154,9 +154,16 @@ export class ComponentWorkspaceService {
             payload: component,
             userId,
             trx,
+            isImport: true,
           });
         } else {
-          await this.createComponent(locationId, component, userId, trx);
+          await this.createComponent({
+            locationId,
+            payload: component,
+            userId,
+            trx,
+            isImport: true,
+          });
           compRecord = await repository.getComponentByLocIdAndCompId(
             locationId,
             component.componentId,
@@ -181,12 +188,14 @@ export class ComponentWorkspaceService {
   async updateComponent({
     locationId,
     componentRecord,
+    isImport = false,
     payload,
     userId,
     trx,
   }: {
     locationId: string;
     componentRecord: Component;
+    isImport?: boolean;
     payload: UpdateComponentBaseDTO;
     userId: string;
     trx?: EntityManager;
@@ -206,17 +215,26 @@ export class ComponentWorkspaceService {
       componentRecord,
     );
 
-    await this.mpService.resetToNeedsEvaluation(locationId, userId, trx);
+    if (!isImport) {
+      await this.mpService.resetToNeedsEvaluation(locationId, userId, trx);
+    }
 
     return this.map.one(result);
   }
 
-  async createComponent(
-    locationId: string,
-    payload: UpdateComponentBaseDTO,
-    userId: string,
-    trx?: EntityManager,
-  ): Promise<ComponentDTO> {
+  async createComponent({
+    locationId,
+    payload,
+    userId,
+    trx,
+    isImport = false,
+  }: {
+    isImport?: boolean;
+    locationId: string;
+    payload: UpdateComponentBaseDTO;
+    userId: string;
+    trx?: EntityManager;
+  }): Promise<ComponentDTO> {
     const repository = withTransaction(this.repository, trx);
     const component = repository.create({
       id: uuid(),
@@ -236,7 +254,9 @@ export class ComponentWorkspaceService {
 
     const result = await repository.save(component);
 
-    await this.mpService.resetToNeedsEvaluation(locationId, userId, trx);
+    if (!isImport) {
+      await this.mpService.resetToNeedsEvaluation(locationId, userId, trx);
+    }
 
     return this.map.one(result);
   }

--- a/src/entities/workspace/monitor-plan-location.entity.ts
+++ b/src/entities/workspace/monitor-plan-location.entity.ts
@@ -8,7 +8,7 @@ import {
 } from 'typeorm';
 
 import { MonitorLocation } from './monitor-location.entity';
-import { MonitorPlan } from '../monitor-plan.entity';
+import { MonitorPlan } from './monitor-plan.entity';
 
 @Entity({ name: 'camdecmpswks.monitor_plan_location' })
 export class MonitorPlanLocation extends BaseEntity {

--- a/src/mats-method-workspace/mats-method.service.ts
+++ b/src/mats-method-workspace/mats-method.service.ts
@@ -141,7 +141,7 @@ export class MatsMethodWorkspaceService {
   ) {
     await Promise.all(
       matsMethods.map(async matsMethod => {
-        let method = await withTransaction(
+        const method = await withTransaction(
           this.repository,
           trx,
         ).getMatsMethodByLodIdParamCodeAndDate(locationId, matsMethod);

--- a/src/monitor-load-workspace/monitor-load.service.ts
+++ b/src/monitor-load-workspace/monitor-load.service.ts
@@ -74,6 +74,7 @@ export class MonitorLoadWorkspaceService {
             payload: load,
             userId,
             trx,
+            isImport: true,
           });
         } else {
           await this.createLoad({
@@ -140,12 +141,14 @@ export class MonitorLoadWorkspaceService {
     payload,
     userId,
     trx,
+    isImport = false,
   }: {
     locationId: string;
     loadId: string;
     payload: MonitorLoadBaseDTO;
     userId: string;
     trx?: EntityManager;
+    isImport?: boolean;
   }): Promise<MonitorLoadDTO> {
     const load = await this.getLoad(loadId, trx);
 
@@ -165,7 +168,11 @@ export class MonitorLoadWorkspaceService {
     load.updateDate = currentDateTime();
 
     await withTransaction(this.repository, trx).save(load);
-    await this.mpService.resetToNeedsEvaluation(locationId, userId, trx);
+
+    if (!isImport) {
+      await this.mpService.resetToNeedsEvaluation(locationId, userId, trx);
+    }
+
     return this.map.one(load);
   }
 }

--- a/src/monitor-location-workspace/monitor-location.service.ts
+++ b/src/monitor-location-workspace/monitor-location.service.ts
@@ -39,7 +39,7 @@ import { MonitorLocationWorkspaceRepository } from './monitor-location.repositor
 
 @Injectable()
 export class MonitorLocationWorkspaceService {
-  readonly errorMsg:string = 'Monitor Location Not Found';
+  readonly errorMsg: string = 'Monitor Location Not Found';
   constructor(
     private readonly repository: MonitorLocationWorkspaceRepository,
     private readonly map: MonitorLocationMap,

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -16,7 +16,11 @@ import { SingleUnitMonitorPlanRequestDTO } from '../dtos/single-unit-monitor-pla
 import { MonitorPlanWorkspaceService } from './monitor-plan.service';
 
 import { ImportChecksService } from '../import-checks/import-checks.service';
-import { AuditLog, RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
+import {
+  AuditLog,
+  RoleGuard,
+  User,
+} from '@us-epa-camd/easey-common/decorators';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { MonitorPlanChecksService } from './monitor-plan-checks.service';
@@ -33,7 +37,7 @@ export class MonitorPlanWorkspaceController {
     private readonly service: MonitorPlanWorkspaceService,
     private readonly importChecksService: ImportChecksService,
     private readonly mpChecksService: MonitorPlanChecksService,
-  ) { }
+  ) {}
 
   @Get('export')
   @ApiOkResponse({
@@ -50,7 +54,7 @@ export class MonitorPlanWorkspaceController {
   )
   @AuditLog({
     label: 'Exported monitoring plan',
-    requestQueryOutFields: ['planId']
+    requestQueryOutFields: ['planId'],
   })
   exportMonitorPlan(@Query() params: MonitorPlanParamsDTO) {
     return this.service.exportMonitorPlan(
@@ -75,7 +79,7 @@ export class MonitorPlanWorkspaceController {
   )
   @AuditLog({
     label: 'Retrieved monitoring plan',
-    requestParamsOutFields: ['planId']
+    requestParamsOutFields: ['planId'],
   })
   getMonitorPlan(@Param('planId') planId: string): Promise<MonitorPlanDTO> {
     return this.service.getMonitorPlan(planId);
@@ -96,7 +100,12 @@ export class MonitorPlanWorkspaceController {
   })
   @AuditLog({
     label: 'Imported monitoring plan',
-    requestBodyOutFields: ['orisCode','unitStackConfigurationData.unitId', 'unitStackConfigurationData.stackPipeId', 'monitoringLocationData.unitId']
+    requestBodyOutFields: [
+      'orisCode',
+      'unitStackConfigurationData.unitId',
+      'unitStackConfigurationData.stackPipeId',
+      'monitoringLocationData.unitId',
+    ],
   })
   async importPlan(
     @Body() plan: UpdateMonitorPlanDTO,

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -1633,6 +1633,7 @@ export class MonitorPlanWorkspaceService {
     const repository = withTransaction(this.repository, trx);
 
     const plan = await repository.getActivePlanByLocationId(locId);
+    if (!plan) return;
 
     const planId = plan.id;
 

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -1095,7 +1095,7 @@ export class MonitorPlanWorkspaceService {
       /* MONITOR LOCATION MERGE LOGIC */
 
       this.logger.log('Importing monitor locations');
-      await this.monitorLocationService.importMonitorLocations(
+      const monitorLocations = await this.monitorLocationService.importMonitorLocations(
         payload,
         facilityId,
         userId,
@@ -1190,6 +1190,13 @@ export class MonitorPlanWorkspaceService {
           trx,
         );
       }
+
+      // Reset all active monitor plans associated with locations in the import to "needs evaluation".
+      await Promise.all(
+        monitorLocations.map(async loc =>
+          this.resetToNeedsEvaluation(loc.id, userId, trx),
+        ),
+      );
 
       if (draft) {
         // Rollback the transaction if the operation is a draft.

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -169,11 +169,13 @@ export class MonitorPlanWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
+    const repository = withTransaction(this.repository, trx);
+
     // Get the first single-unit monitor plan associated with the method.
-    const firstPlan = await withTransaction(this.repository, trx)
+    const firstPlan = await repository
       .createQueryBuilder('mp')
       .innerJoinAndSelect('mp.beginReportingPeriod', 'brp')
-      .innerJoinAndSelect('mp.endReportingPeriod', 'erp')
+      .leftJoinAndSelect('mp.endReportingPeriod', 'erp')
       .innerJoin('mp.monitorPlanLocations', 'mpl')
       .innerJoin('mpl.monitorLocation', 'ml')
       .innerJoin('ml.methods', 'm')
@@ -214,7 +216,6 @@ export class MonitorPlanWorkspaceService {
       planBeginQuarter !== methodBeginQuarter
     ) {
       // Make sure the new begin date is not after the end date of the monitor plan.
-      // TODO: Does this need more checks?
       if (firstPlan.endReportingPeriod) {
         const planEndYear = firstPlan.endReportingPeriod.year;
         const planEndQuarter = firstPlan.endReportingPeriod.quarter;
@@ -236,10 +237,10 @@ export class MonitorPlanWorkspaceService {
         beginReportPeriod:
           earliestMethodBeginReportingPeriod.periodAbbreviation,
       });
-      firstPlan.beginReportPeriodId = earliestMethodBeginReportingPeriod.id;
-      firstPlan.updateDate = currentDateTime();
-      const repository = withTransaction(this.repository, trx);
-      await repository.save(firstPlan);
+      await repository.update(firstPlan.id, {
+        beginReportPeriodId: earliestMethodBeginReportingPeriod.id,
+        updateDate: currentDateTime(),
+      });
       await repository.resetToNeedsEvaluation(firstPlan.id, userId);
     }
   }

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -1636,9 +1636,7 @@ export class MonitorPlanWorkspaceService {
     const plan = await repository.getActivePlanByLocationId(locId);
     if (!plan) return;
 
-    const planId = plan.id;
-
-    await repository.resetToNeedsEvaluation(planId, userId);
+    await repository.resetToNeedsEvaluation(plan.id, userId);
   }
 
   async exportMonitorPlan(

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -1169,6 +1169,7 @@ export class MonitorPlanWorkspaceService {
       /* MONITOR PLAN COMMENT MERGE LOGIC */
 
       // Apply the monitor plan comments to the earliest changed plan.
+      // NOTE:XXX: This is not a great way to determine the target plan: if the import doesn't contain any new or ended plans, the comments will not be imported. However, since the import schema can contain multiple plans, it is impossible to determine the target plan without additional information.
       const targetPlan = [...result.newPlans, ...result.endedPlans].reduce(
         (acc, cur) => {
           if (!acc) return cur;

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -169,54 +169,78 @@ export class MonitorPlanWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    // Get the first single-unit moitor plan associated with the method.
-    const firstPlanRecord = await withTransaction(this.repository, trx)
+    // Get the first single-unit monitor plan associated with the method.
+    const firstPlan = await withTransaction(this.repository, trx)
       .createQueryBuilder('mp')
+      .innerJoinAndSelect('mp.beginReportingPeriod', 'brp')
+      .innerJoinAndSelect('mp.endReportingPeriod', 'erp')
       .innerJoin('mp.monitorPlanLocations', 'mpl')
       .innerJoin('mpl.monitorLocation', 'ml')
-      .innerJoin('mp.beginReportingPeriod', 'brp')
-      .where(qb => {
-        const subQuery = qb
-          .subQuery()
-          .select('COUNT(*)')
-          .from(MonitorLocationWorkspace, 'ml')
-          .innerJoin('ml.methods', 'm')
-          .where('m.id = :methodId', {
-            methodId: method.id,
-          })
-          .getQuery();
-        return `(${subQuery}) = 1`;
-      })
-      .andWhere('ml.unitId IS NOT NULL')
+      .innerJoin('ml.methods', 'm')
+      .where('m.id = :methodId', { methodId: method.id })
       .orderBy('brp.beginDate', 'ASC')
+      .limit(1)
       .getOne();
 
-    if (!firstPlanRecord) return;
+    if (!firstPlan) {
+      this.logger.debug(
+        `No monitor plan found for the method with id "${method.id}"`,
+      );
+      return;
+    }
 
-    // Update the begin reporting period of the monitor plan if the method's begin date is earlier.
-    const [
-      firstPlanReportingPeriod,
-      methodBeginReportingPeriod,
-    ] = await Promise.all([
-      this.reportingPeriodRepository.getById(
-        firstPlanRecord.beginReportPeriodId,
-      ),
-      this.reportingPeriodRepository.getByDate(method.beginDate),
-    ]);
+    const earliestMethod = await withTransaction(this.methodRepository, trx)
+      .createQueryBuilder('m')
+      .innerJoin('m.location', 'ml')
+      .innerJoin('ml.monitorPlanLocations', 'mpl')
+      .innerJoin('mpl.monitorPlan', 'mp')
+      .where('mp.id = :monitorPlanId', { monitorPlanId: firstPlan.id })
+      .orderBy('m.beginDate', 'ASC')
+      .limit(1)
+      .getOne();
+
+    const earliestMethodBeginReportingPeriod = await this.reportingPeriodRepository.getByDate(
+      earliestMethod.beginDate,
+    );
+
+    const planBeginYear = firstPlan.beginReportingPeriod.year;
+    const planBeginQuarter = firstPlan.beginReportingPeriod.quarter;
+    const methodBeginYear = earliestMethodBeginReportingPeriod.year;
+    const methodBeginQuarter = earliestMethodBeginReportingPeriod.quarter;
+
+    // Update the begin reporting period of the monitor plan to the method's begin date if they differ.
     if (
-      methodBeginReportingPeriod.year < firstPlanReportingPeriod.year ||
-      (methodBeginReportingPeriod.year === firstPlanReportingPeriod.year &&
-        methodBeginReportingPeriod.quarter < firstPlanReportingPeriod.quarter)
+      planBeginYear !== methodBeginYear ||
+      planBeginQuarter !== methodBeginQuarter
     ) {
+      // Make sure the new begin date is not after the end date of the monitor plan.
+      // TODO: Does this need more checks?
+      if (firstPlan.endReportingPeriod) {
+        const planEndYear = firstPlan.endReportingPeriod.year;
+        const planEndQuarter = firstPlan.endReportingPeriod.quarter;
+        if (
+          methodBeginYear > planEndYear ||
+          (methodBeginYear === planEndYear &&
+            methodBeginQuarter > planEndQuarter)
+        ) {
+          throw new EaseyException(
+            new Error(
+              'The method begin date is after the monitor plan end date',
+            ),
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+      }
       this.logger.debug('Updating the monitor plan begin reporting period', {
-        monPlanId: firstPlanRecord.id,
-        beginReportPeriod: methodBeginReportingPeriod.periodAbbreviation,
+        monPlanId: firstPlan.id,
+        beginReportPeriod:
+          earliestMethodBeginReportingPeriod.periodAbbreviation,
       });
-      firstPlanRecord.beginReportPeriodId = methodBeginReportingPeriod.id;
-      firstPlanRecord.updateDate = currentDateTime();
+      firstPlan.beginReportPeriodId = earliestMethodBeginReportingPeriod.id;
+      firstPlan.updateDate = currentDateTime();
       const repository = withTransaction(this.repository, trx);
-      await repository.save(firstPlanRecord);
-      await repository.resetToNeedsEvaluation(firstPlanRecord.id, userId);
+      await repository.save(firstPlan);
+      await repository.resetToNeedsEvaluation(firstPlan.id, userId);
     }
   }
 
@@ -482,8 +506,19 @@ export class MonitorPlanWorkspaceService {
       unitId,
       userId,
     });
+
+    // If there is an existing method on the unit, use that begin date for the begin reporting period.
+    // Otherwise, use the current date.
+    const firstMethod = await this.methodRepository.findOne({
+      order: { beginDate: 'ASC' },
+      where: {
+        locationId: location.id,
+      },
+    });
     const beginReportPeriodId = (
-      await this.reportingPeriodRepository.getByDate(new Date())
+      await this.reportingPeriodRepository.getByDate(
+        firstMethod?.beginDate ?? new Date(),
+      )
     ).id;
 
     // Start a transaction.

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,0 +1,8 @@
+import { repl } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  await repl(AppModule);
+}
+
+bootstrap();


### PR DESCRIPTION
## Related Issues:

- [#6425](https://github.com/US-EPA-CAMD/easey-ui/issues/6425)

## Main Changes:

- Changed the implementation of `updatePlanPeriodOnMethodUpdate` to update the reporting period of the earliest monitoring plan associated with a new or updated plan to the begin date of the earliest method associated with that plan.
- Added the `isImport` flag in several places where it was missing. The absence was causing imports to fail in some cases if the MP did not yet exist.
- Added back in the top-level `resetToNeedsEvaluation` so the import behaves more closely to how it did previously.