### PR TITLE
Fix/6621 query outside transaction

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,6 @@ module.exports = {
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [
     'plugin:@typescript-eslint/recommended',
-    'prettier/@typescript-eslint',
     'plugin:prettier/recommended',
   ],
   root: true,

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-prettier": "^5.2.3",
     "jest": "^27.3.1",
     "jest-sonar-reporter": "^2.0.0",
     "prettier": "^1.19.1",

--- a/src/analyzer-range-workspace/analyzer-range.service.ts
+++ b/src/analyzer-range-workspace/analyzer-range.service.ts
@@ -12,7 +12,7 @@ import {
 import { AnalyzerRange } from '../entities/workspace/analyzer-range.entity';
 import { AnalyzerRangeMap } from '../maps/analyzer-range.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { AnalyzerRangeWorkspaceRepository } from './analyzer-range.repository';
 
 @Injectable()
@@ -134,7 +134,7 @@ export class AnalyzerRangeWorkspaceService {
     analyzerRanges: AnalyzerRangeBaseDTO[] = [],
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       analyzerRanges.map(async analyzerRange => {
         const analyzerRangeRecord = await withTransaction(
           this.repository,

--- a/src/component-workspace/component.service.ts
+++ b/src/component-workspace/component.service.ts
@@ -11,7 +11,7 @@ import { Component } from '../entities/workspace/component.entity';
 import { ComponentMap } from '../maps/component.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { UsedIdentifierRepository } from '../used-identifier/used-identifier.repository';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { ComponentWorkspaceRepository } from './component.repository';
 
 @Injectable()
@@ -126,7 +126,7 @@ export class ComponentWorkspaceService {
     trx?: EntityManager,
   ) {
     const repository = withTransaction(this.repository, trx);
-    await Promise.all(
+    await settlePromises(
       location.componentData.map(async component => {
         let compRecord = await repository.getComponentByLocIdAndCompId(
           locationId,

--- a/src/duct-waf-workspace/duct-waf.service.ts
+++ b/src/duct-waf-workspace/duct-waf.service.ts
@@ -9,7 +9,7 @@ import { DuctWafBaseDTO, DuctWafDTO } from '../dtos/duct-waf.dto';
 import { DuctWaf } from '../entities/duct-waf.entity';
 import { DuctWafMap } from '../maps/duct-waf.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { DuctWafWorkspaceRepository } from './duct-waf.repository';
 
 @Injectable()
@@ -141,7 +141,7 @@ export class DuctWafWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       ductWafs.map(async ductWaf => {
         const ductWafRecord = await withTransaction(
           this.repository,

--- a/src/lee-qualification-workspace/lee-qualification.service.ts
+++ b/src/lee-qualification-workspace/lee-qualification.service.ts
@@ -12,7 +12,7 @@ import {
 import { LEEQualificationMap } from '../maps/lee-qualification.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { MonitorQualificationWorkspaceService } from '../monitor-qualification-workspace/monitor-qualification.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { LEEQualificationWorkspaceRepository } from './lee-qualification.repository';
 
 @Injectable()
@@ -184,7 +184,7 @@ export class LEEQualificationWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    return Promise.all(
+    return settlePromises(
       leeQualifications.map(async leeQualification => {
         const leeQualificationRecord = await withTransaction(
           this.repository,

--- a/src/lme-qualification-workspace/lme-qualification.service.ts
+++ b/src/lme-qualification-workspace/lme-qualification.service.ts
@@ -12,7 +12,7 @@ import {
 import { LMEQualificationMap } from '../maps/lme-qualification.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { MonitorQualificationWorkspaceService } from '../monitor-qualification-workspace/monitor-qualification.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { LMEQualificationWorkspaceRepository } from './lme-qualification.repository';
 
 @Injectable()
@@ -181,7 +181,7 @@ export class LMEQualificationWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    return Promise.all(
+    return settlePromises(
       lmeQualifications.map(async lmeQualification => {
         const lmeQualRecord = await this.getLMEQualificationByDataYear(
           locationId,

--- a/src/mats-method-workspace/mats-method.service.ts
+++ b/src/mats-method-workspace/mats-method.service.ts
@@ -8,7 +8,7 @@ import { v4 as uuid } from 'uuid';
 import { MatsMethodBaseDTO, MatsMethodDTO } from '../dtos/mats-method.dto';
 import { MatsMethodMap } from '../maps/mats-method.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MatsMethodWorkspaceRepository } from './mats-method.repository';
 
 @Injectable()
@@ -139,7 +139,7 @@ export class MatsMethodWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       matsMethods.map(async matsMethod => {
         const method = await withTransaction(
           this.repository,

--- a/src/monitor-attribute-workspace/monitor-attribute.service.ts
+++ b/src/monitor-attribute-workspace/monitor-attribute.service.ts
@@ -11,7 +11,7 @@ import {
 } from '../dtos/monitor-attribute.dto';
 import { MonitorAttributeMap } from '../maps/monitor-attribute.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorAttributeWorkspaceRepository } from './monitor-attribute.repository';
 
 @Injectable()
@@ -152,12 +152,16 @@ export class MonitorAttributeWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       attributes.map(async attribute => {
         const attributeRecord = await withTransaction(
           this.repository,
           trx,
-        ).getAttributeByLocIdAndDate(locationId, attribute.beginDate, attribute.endDate);
+        ).getAttributeByLocIdAndDate(
+          locationId,
+          attribute.beginDate,
+          attribute.endDate,
+        );
 
         if (attributeRecord) {
           await this.updateAttribute({

--- a/src/monitor-default-workspace/monitor-default.service.ts
+++ b/src/monitor-default-workspace/monitor-default.service.ts
@@ -12,7 +12,7 @@ import {
 import { MonitorDefault } from '../entities/workspace/monitor-default.entity';
 import { MonitorDefaultMap } from '../maps/monitor-default.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorDefaultWorkspaceRepository } from './monitor-default.repository';
 
 @Injectable()
@@ -148,7 +148,7 @@ export class MonitorDefaultWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       monDefaults.map(async monDefault => {
         const monDefaultRecord = await withTransaction(
           this.repository,

--- a/src/monitor-formula-workspace/monitor-formula.service.ts
+++ b/src/monitor-formula-workspace/monitor-formula.service.ts
@@ -13,7 +13,7 @@ import { MonitorFormula } from '../entities/workspace/monitor-formula.entity';
 import { MonitorFormulaMap } from '../maps/monitor-formula.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { UsedIdentifierRepository } from '../used-identifier/used-identifier.repository';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorFormulaWorkspaceRepository } from './monitor-formula.repository';
 
 @Injectable()
@@ -178,7 +178,7 @@ export class MonitorFormulaWorkspaceService {
   ) {
     const repository = withTransaction(this.repository, trx);
 
-    await Promise.all(
+    await settlePromises(
       formulas.map(async formula => {
         let formulaRecord = await repository.getFormulaByLocIdAndFormulaIdentifier(
           locationId,

--- a/src/monitor-load-workspace/monitor-load.service.ts
+++ b/src/monitor-load-workspace/monitor-load.service.ts
@@ -9,7 +9,7 @@ import { MonitorLoadBaseDTO, MonitorLoadDTO } from '../dtos/monitor-load.dto';
 import { MonitorLoad } from '../entities/workspace/monitor-load.entity';
 import { MonitorLoadMap } from '../maps/monitor-load.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorLoadWorkspaceRepository } from './monitor-load.repository';
 
 @Injectable()
@@ -54,7 +54,7 @@ export class MonitorLoadWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       loads.map(async load => {
         const loadRecord = await withTransaction(
           this.repository,

--- a/src/monitor-location-workspace/monitor-location.service.ts
+++ b/src/monitor-location-workspace/monitor-location.service.ts
@@ -594,7 +594,7 @@ export class MonitorLocationWorkspaceService {
           );
         }
 
-        await Promise.all(innerPromises);
+        await settlePromises(innerPromises);
         locations.push(
           await this.getLocation(monitorLocationRecord.id, trx), // Re-query the location to populate newly added relationships
         );

--- a/src/monitor-location-workspace/monitor-location.service.ts
+++ b/src/monitor-location-workspace/monitor-location.service.ts
@@ -34,7 +34,7 @@ import { UnitControlWorkspaceService } from '../unit-control-workspace/unit-cont
 import { UnitFuelWorkspaceService } from '../unit-fuel-workspace/unit-fuel.service';
 import { UnitStackConfigurationWorkspaceService } from '../unit-stack-configuration-workspace/unit-stack-configuration.service';
 import { UnitService } from '../unit/unit.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorLocationWorkspaceRepository } from './monitor-location.repository';
 
 @Injectable()
@@ -356,7 +356,7 @@ export class MonitorLocationWorkspaceService {
   ) {
     const locations: MonitorLocationDTO[] = [];
 
-    await Promise.all(
+    await settlePromises(
       plan.monitoringLocationData.map(async location => {
         const innerPromises = [];
 

--- a/src/monitor-method-workspace/monitor-method.service.ts
+++ b/src/monitor-method-workspace/monitor-method.service.ts
@@ -12,7 +12,7 @@ import {
 import { MonitorMethod } from '../entities/workspace/monitor-method.entity';
 import { MonitorMethodMap } from '../maps/monitor-method.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorMethodWorkspaceRepository } from './monitor-method.repository';
 
 @Injectable()
@@ -149,7 +149,7 @@ export class MonitorMethodWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       methods.map(async method => {
         const methodRecord = await withTransaction(
           this.repository,

--- a/src/monitor-plan-comment-workspace/monitor-plan-comment.service.ts
+++ b/src/monitor-plan-comment-workspace/monitor-plan-comment.service.ts
@@ -3,7 +3,7 @@ import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { EntityManager } from 'typeorm';
 import { v4 } from 'uuid';
 
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import {
   MonitorPlanCommentBaseDTO,
   MonitorPlanCommentDTO,
@@ -97,7 +97,7 @@ export class MonitorPlanCommentWorkspaceService {
     monitorPlanId: string,
     trx?: EntityManager,
   ) {
-    return Promise.all(
+    return settlePromises(
       commentData.map(async comment => {
         const monitorPlanComment = await this.getCommentsByPlanIdCommentBD(
           monitorPlanId,

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -54,7 +54,7 @@ import { UnitStackConfigurationWorkspaceService } from '../unit-stack-configurat
 import { UnitWorkspaceService } from '../unit-workspace/unit.service';
 import { UserCheckOutService } from '../user-check-out/user-check-out.service';
 import { removeNonReportedValues } from '../utilities/remove-non-reported-values';
-import { throwIfErrors, withTransaction } from '../utils';
+import { settlePromises, throwIfErrors, withTransaction } from '../utils';
 import { MonitorPlanWorkspaceRepository } from './monitor-plan.repository';
 
 @Injectable()
@@ -1142,7 +1142,7 @@ export class MonitorPlanWorkspaceService {
 
       // Compare each working plan to the previous database state and update accordingly.
       result = (
-        await Promise.all(
+        await settlePromises(
           workingPlans.map(workingPlan =>
             this.syncMonitorPlan({
               workingPlan,
@@ -1193,7 +1193,7 @@ export class MonitorPlanWorkspaceService {
       }
 
       // Reset all active monitor plans associated with locations in the import to "needs evaluation".
-      await Promise.all(
+      await settlePromises(
         monitorLocations.map(async loc =>
           this.resetToNeedsEvaluation(loc.id, userId, trx),
         ),

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -40,6 +40,7 @@ import { MonitorSpanWorkspaceRepository } from '../monitor-span-workspace/monito
 import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system.repository';
 import { PCTQualificationWorkspaceRepository } from '../pct-qualification-workspace/pct-qualification.repository';
 import { PlantService } from '../plant/plant.service';
+import { ReportingPeriod } from '../entities/workspace/reporting-period.entity';
 import { ReportingPeriodRepository } from '../reporting-period/reporting-period.repository';
 import { SystemComponentWorkspaceRepository } from '../system-component-workspace/system-component.repository';
 import { SystemFuelFlowWorkspaceRepository } from '../system-fuel-flow-workspace/system-fuel-flow.repository';
@@ -280,6 +281,11 @@ export class MonitorPlanWorkspaceService {
     endReportPeriodId: number;
     trx?: EntityManager;
   }) {
+    const reportingPeriodRepository = withTransaction(
+      this.reportingPeriodRepository,
+      trx,
+    );
+
     // Create the `monitor_plan` record.
     const monitorPlanRecord = await withTransaction(
       this.repository,
@@ -292,7 +298,7 @@ export class MonitorPlanWorkspaceService {
     );
 
     // Create the `monitor_plan_location` record(s).
-    await Promise.all(
+    await settlePromises(
       locations.map(l =>
         this.monitorPlanLocationService.createMonPlanLocationRecord(
           monitorPlanRecord.id,
@@ -312,22 +318,20 @@ export class MonitorPlanWorkspaceService {
     ).getUnitProgramsByUnitRecordIds(unitRecordIds);
 
     // Get the program ranges and types from the unit programs.
-    const programRanges: ProgramRange[] = await Promise.all(
+    const programRanges: ProgramRange[] = await settlePromises<ProgramRange>(
       unitPrograms
         .filter(up => up.unitMonitorCertBeginDate !== null)
         .map(async up => {
-          const [begin, end] = await Promise.all([
-            this.reportingPeriodRepository.getByDate(
-              up.unitMonitorCertBeginDate,
-            ),
-            up.endDate && this.reportingPeriodRepository.getByDate(up.endDate),
+          const [begin, end] = await settlePromises<ReportingPeriod>([
+            reportingPeriodRepository.getByDate(up.unitMonitorCertBeginDate),
+            up.endDate && reportingPeriodRepository.getByDate(up.endDate),
           ]);
           return {
             type:
               up.program.code.ozoneSeasonIndicator === 1 ? 'ozone' : 'annual',
             begin: { year: begin.year, quarter: begin.quarter },
             end: end && { year: end.year, quarter: end.quarter },
-          };
+          } as ProgramRange;
         }),
     );
 
@@ -421,7 +425,7 @@ export class MonitorPlanWorkspaceService {
     const freqRanges = getFrequencyRanges(periodFreqAssoc);
 
     // Create the reporting frequency records.
-    await Promise.all(
+    await settlePromises(
       freqRanges.map(async ([begin, end], i) => {
         const [beginYear, beginQuarter, beginFreq] = begin;
         const [endYear, endQuarter, endFreq] = end;
@@ -434,12 +438,9 @@ export class MonitorPlanWorkspaceService {
             HttpStatus.INTERNAL_SERVER_ERROR,
           );
         }
-        const [beginReportPeriod, endReportPeriod] = await Promise.all([
-          this.reportingPeriodRepository.getByYearQuarter(
-            beginYear,
-            beginQuarter,
-          ),
-          this.reportingPeriodRepository.getByYearQuarter(endYear, endQuarter),
+        const [beginReportPeriod, endReportPeriod] = await settlePromises([
+          reportingPeriodRepository.getByYearQuarter(beginYear, beginQuarter),
+          reportingPeriodRepository.getByYearQuarter(endYear, endQuarter),
         ]);
         await withTransaction(
           this.reportingFreqRepository,
@@ -1687,7 +1688,7 @@ export class MonitorPlanWorkspaceService {
       { earliestRf: null, latestRf: null },
     );
 
-    await Promise.all(deletePromises);
+    await settlePromises(deletePromises);
 
     if (
       latestRf &&

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -1206,7 +1206,7 @@ export class MonitorPlanWorkspaceService {
       }
     } catch (err) {
       await queryRunner.rollbackTransaction();
-      throw err;
+      throw new EaseyException(new Error(err.message), HttpStatus.BAD_REQUEST);
     } finally {
       await queryRunner.release();
     }

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -10,14 +10,12 @@ import { AnalyzerRangeWorkspaceRepository } from '../analyzer-range-workspace/an
 import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
 import { MonitorLocationDTO } from '../dtos/monitor-location.dto';
 import { MonitorMethodDTO } from '../dtos/monitor-method.dto';
-import { MonitorPlanReportingFrequency } from '../entities/workspace/monitor-plan-reporting-freq.entity';
 import { MonitorPlan as MonitorPlanWorkspace } from '../entities/workspace/monitor-plan.entity';
 import { UpdateMonitorPlanDTO } from '../dtos/monitor-plan-update.dto';
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
 import { UnitDTO } from '../dtos/unit.dto';
 import { UnitStackConfigurationDTO } from '../dtos/unit-stack-configuration.dto';
 import { DuctWafWorkspaceRepository } from '../duct-waf-workspace/duct-waf.repository';
-import { MonitorLocation as MonitorLocationWorkspace } from '../entities/workspace/monitor-location.entity';
 import { LEEQualificationWorkspaceRepository } from '../lee-qualification-workspace/lee-qualification.repository';
 import { LMEQualificationWorkspaceRepository } from '../lme-qualification-workspace/lme-qualification.repository';
 import { MonitorPlanMap } from '../maps/monitor-plan.map';
@@ -1086,6 +1084,17 @@ export class MonitorPlanWorkspaceService {
       newPlans: MonitorPlanDTO[];
     } = { endedPlans: [], newPlans: [] };
 
+    // Get a list of existing monitor plans from the database.
+    const existingPlans = await this.repository.find({
+      where: { facId: facilityId },
+      relations: {
+        locations: {
+          unit: true,
+          stackPipe: true,
+        },
+      },
+    });
+
     // Start a transaction.
     const queryRunner = this.entityManager.connection.createQueryRunner();
     await queryRunner.startTransaction();
@@ -1128,17 +1137,6 @@ export class MonitorPlanWorkspaceService {
 
       // Check the configurations for validity.
       this.runConfigurationChecks(workingPlans);
-
-      // Get a list of existing monitor plans from the database (outside of the transaction).
-      const existingPlans = await this.repository.find({
-        where: { facId: facilityId },
-        relations: {
-          locations: {
-            unit: true,
-            stackPipe: true,
-          },
-        },
-      });
 
       // Compare each working plan to the previous database state and update accordingly.
       result = (
@@ -1240,7 +1238,7 @@ export class MonitorPlanWorkspaceService {
     });
   }
 
-  private async matchToPlanByLocationsAndBeginPeriod(
+  private matchToPlanByLocationsAndBeginPeriod(
     locationIds: { unitIds: Set<string>; stackPipeIds: Set<string> },
     existingPlans: MonitorPlanWorkspace[],
     beginReportPeriodId: number,
@@ -1253,7 +1251,7 @@ export class MonitorPlanWorkspaceService {
     );
   }
 
-  private async matchToPlanByLocationsAndEndPeriod(
+  private matchToPlanByLocationsAndEndPeriod(
     locationIds: { unitIds: Set<string>; stackPipeIds: Set<string> },
     existingPlans: MonitorPlanWorkspace[],
     endReportPeriodId: number | null,
@@ -1266,7 +1264,7 @@ export class MonitorPlanWorkspaceService {
     );
   }
 
-  private async matchToPlanByLocationsAndPeriod(
+  private matchToPlanByLocationsAndPeriod(
     locationIds: { unitIds: Set<string>; stackPipeIds: Set<string> },
     existingPlans: MonitorPlanWorkspace[],
     periodId: number | null,
@@ -1307,7 +1305,7 @@ export class MonitorPlanWorkspaceService {
       );
     }
 
-    return this.getMonitorPlan(matchedPlan.id, { full: true });
+    return matchedPlan;
   }
 
   private mergePartialConfigurations(
@@ -1416,10 +1414,10 @@ export class MonitorPlanWorkspaceService {
     const planEndReportPeriodId =
       workingPlan.endYear && workingPlan.endQuarter
         ? (
-            await this.reportingPeriodRepository.getByYearQuarter(
-              workingPlan.endYear,
-              workingPlan.endQuarter,
-            )
+            await withTransaction(
+              this.reportingPeriodRepository,
+              trx,
+            ).getByYearQuarter(workingPlan.endYear, workingPlan.endQuarter)
           ).id
         : null;
 
@@ -1428,13 +1426,13 @@ export class MonitorPlanWorkspaceService {
 
     // Match the working plan to an existing monitor plan by locations and end period.
     const matchedPlan =
-      (await this.matchToPlanByLocationsAndEndPeriod(
+      this.matchToPlanByLocationsAndEndPeriod(
         locationIds,
         existingPlans,
         planEndReportPeriodId,
-      )) ??
+      ) ??
       (planEndReportPeriodId !== null
-        ? await this.matchToPlanByLocationsAndEndPeriod(
+        ? this.matchToPlanByLocationsAndEndPeriod(
             locationIds,
             existingPlans,
             null,
@@ -1492,9 +1490,14 @@ export class MonitorPlanWorkspaceService {
       });
     }
 
+    const reportingPeriodRepository = withTransaction(
+      this.reportingPeriodRepository,
+      trx,
+    );
+
     // Calculate the report period range from the working monitor plan.
     const planBeginReportPeriodId = (
-      await this.reportingPeriodRepository.getByYearQuarter(
+      await reportingPeriodRepository.getByYearQuarter(
         workingPlan.beginYear,
         workingPlan.beginQuarter,
       )
@@ -1502,7 +1505,7 @@ export class MonitorPlanWorkspaceService {
     const planEndReportPeriodId =
       workingPlan.endYear && workingPlan.endQuarter
         ? (
-            await this.reportingPeriodRepository.getByYearQuarter(
+            await reportingPeriodRepository.getByYearQuarter(
               workingPlan.endYear,
               workingPlan.endQuarter,
             )
@@ -1513,7 +1516,7 @@ export class MonitorPlanWorkspaceService {
     const locationIds = this.getItemLocationIds(workingPlan.items);
 
     // Match the working plan to an existing monitor plan by locations and begin period.
-    const matchedPlan = await this.matchToPlanByLocationsAndBeginPeriod(
+    const matchedPlan = this.matchToPlanByLocationsAndBeginPeriod(
       locationIds,
       existingPlans,
       planBeginReportPeriodId,
@@ -1561,7 +1564,7 @@ export class MonitorPlanWorkspaceService {
   }
 
   async updateEndReportingPeriod(
-    plan: MonitorPlanDTO,
+    plan: MonitorPlanWorkspace,
     newEndReportPeriodId: number,
     userId: string,
     trx?: EntityManager,

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -200,9 +200,10 @@ export class MonitorPlanWorkspaceService {
       .limit(1)
       .getOne();
 
-    const earliestMethodBeginReportingPeriod = await this.reportingPeriodRepository.getByDate(
-      earliestMethod.beginDate,
-    );
+    const earliestMethodBeginReportingPeriod = await withTransaction(
+      this.reportingPeriodRepository,
+      trx,
+    ).getByDate(earliestMethod.beginDate);
 
     const planBeginYear = firstPlan.beginReportingPeriod.year;
     const planBeginQuarter = firstPlan.beginReportingPeriod.quarter;

--- a/src/monitor-qualification-workspace/monitor-qualification.service.ts
+++ b/src/monitor-qualification-workspace/monitor-qualification.service.ts
@@ -16,7 +16,7 @@ import { LMEQualificationWorkspaceService } from '../lme-qualification-workspace
 import { MonitorQualificationMap } from '../maps/monitor-qualification.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { PCTQualificationWorkspaceService } from '../pct-qualification-workspace/pct-qualification.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorQualificationWorkspaceRepository } from './monitor-qualification.repository';
 
 @Injectable()
@@ -135,7 +135,7 @@ export class MonitorQualificationWorkspaceService {
         ),
       );
     }
-    await Promise.all(promises);
+    await settlePromises(promises);
   }
 
   async importQualification(
@@ -144,7 +144,7 @@ export class MonitorQualificationWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       qualifications.map(async qualification => {
         const qualificationRecord = await withTransaction(
           this.repository,

--- a/src/monitor-span-workspace/monitor-span.service.ts
+++ b/src/monitor-span-workspace/monitor-span.service.ts
@@ -9,7 +9,7 @@ import { MonitorSpanBaseDTO, MonitorSpanDTO } from '../dtos/monitor-span.dto';
 import { MonitorSpan } from '../entities/workspace/monitor-span.entity';
 import { MonitorSpanMap } from '../maps/monitor-span.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorSpanWorkspaceRepository } from './monitor-span.repository';
 import { isInactiveRecord } from '../utilities/is-inactive-record';
 
@@ -168,7 +168,13 @@ export class MonitorSpanWorkspaceService {
       }
 
       mustBeNull.forEach(category => {
-        if ((span[category] !== null) && !(category === 'flowFullScaleRange' && isInactiveRecord(span.beginDate, span.endDate))) {
+        if (
+          span[category] !== null &&
+          !(
+            category === 'flowFullScaleRange' &&
+            isInactiveRecord(span.beginDate, span.endDate)
+          )
+        ) {
           errorList.push(
             `[IMPORT10-NONCRIT-A] An extraneous value has been reported for ${category} in the span record for ${span.componentTypeCode}. This value was not imported.`,
           );
@@ -185,7 +191,7 @@ export class MonitorSpanWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ): Promise<boolean> {
-    await Promise.all(
+    await settlePromises(
       spans.map(async span => {
         const spanRecord = await withTransaction(
           this.repository,

--- a/src/monitor-system-workspace/monitor-system.service.ts
+++ b/src/monitor-system-workspace/monitor-system.service.ts
@@ -17,7 +17,7 @@ import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-p
 import { SystemComponentWorkspaceService } from '../system-component-workspace/system-component.service';
 import { SystemFuelFlowWorkspaceService } from '../system-fuel-flow-workspace/system-fuel-flow.service';
 import { UsedIdentifierRepository } from '../used-identifier/used-identifier.repository';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { MonitorSystemWorkspaceRepository } from './monitor-system.repository';
 
 @Injectable()
@@ -205,7 +205,7 @@ export class MonitorSystemWorkspaceService {
       );
     }
 
-    await Promise.all(promises);
+    await settlePromises(promises);
 
     return true;
   }
@@ -252,7 +252,7 @@ export class MonitorSystemWorkspaceService {
     trx?: EntityManager,
   ) {
     const repository = withTransaction(this.repository, trx);
-    await Promise.all(
+    await settlePromises(
       systems.map(async system => {
         const innerPromises = [];
         let systemRecord = await repository.getSystemByLocIdSysIdentifier(
@@ -313,7 +313,7 @@ export class MonitorSystemWorkspaceService {
           );
         }
 
-        await Promise.all(innerPromises);
+        await settlePromises(innerPromises);
       }),
     );
     this.logger.debug(`Imported ${systems.length} systems`);

--- a/src/pct-qualification-workspace/pct-qualification.service.ts
+++ b/src/pct-qualification-workspace/pct-qualification.service.ts
@@ -11,7 +11,7 @@ import {
 import { PCTQualificationMap } from '../maps/pct-qualification.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
 import { MonitorQualificationWorkspaceService } from '../monitor-qualification-workspace/monitor-qualification.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { PCTQualificationWorkspaceRepository } from './pct-qualification.repository';
 
 @Injectable()
@@ -194,7 +194,7 @@ export class PCTQualificationWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    return Promise.all(
+    return settlePromises(
       pctQualifications.map(async pctQualification => {
         const pctQualificationRecord = await this.getPCTQualificationByDataYear(
           locationId,

--- a/src/system-component-workspace/system-component.service.ts
+++ b/src/system-component-workspace/system-component.service.ts
@@ -1,11 +1,10 @@
-import { forwardRef, HttpStatus, Inject, Injectable} from '@nestjs/common';
+import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { EntityManager } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
-import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
 import { ComponentWorkspaceService } from '../component-workspace/component.service';
 import {
   SystemComponentBaseDTO,
@@ -14,7 +13,7 @@ import {
 import { SystemComponent } from '../entities/workspace/system-component.entity';
 import { SystemComponentMap } from '../maps/system-component.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { SystemComponentWorkspaceRepository } from './system-component.repository';
 
 @Injectable()
@@ -174,7 +173,7 @@ export class SystemComponentWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    return Promise.all(
+    return settlePromises(
       systemComponents.map(async component => {
         const systemComponentRecord = await withTransaction(
           this.repository,

--- a/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
+++ b/src/system-fuel-flow-workspace/system-fuel-flow.service.ts
@@ -11,7 +11,7 @@ import {
 import { SystemFuelFlow } from '../entities/workspace/system-fuel-flow.entity';
 import { SystemFuelFlowMap } from '../maps/system-fuel-flow.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { SystemFuelFlowWorkspaceRepository } from './system-fuel-flow.repository';
 
 @Injectable()
@@ -22,7 +22,7 @@ export class SystemFuelFlowWorkspaceService {
 
     @Inject(forwardRef(() => MonitorPlanWorkspaceService))
     private readonly mpService: MonitorPlanWorkspaceService,
-  ) { }
+  ) {}
 
   async getFuelFlows(monSysId: string): Promise<SystemFuelFlowDTO[]> {
     const results = await this.repository.getFuelFlows(monSysId);
@@ -136,7 +136,7 @@ export class SystemFuelFlowWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    return Promise.all(
+    return settlePromises(
       systemFuelFlows.map(async fuelFlow => {
         const fuelFlowRecord = await withTransaction(
           this.repository,

--- a/src/unit-capacity-workspace/unit-capacity.service.ts
+++ b/src/unit-capacity-workspace/unit-capacity.service.ts
@@ -11,7 +11,7 @@ import {
 } from '../dtos/unit-capacity.dto';
 import { UnitCapacityMap } from '../maps/unit-capacity.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { UnitCapacityWorkspaceRepository } from './unit-capacity.repository';
 
 @Injectable()
@@ -34,7 +34,7 @@ export class UnitCapacityWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       unitCapacities.map(async unitCapacity => {
         const unitCapacityRecord = await withTransaction(
           this.repository,

--- a/src/unit-control-workspace/unit-control.service.ts
+++ b/src/unit-control-workspace/unit-control.service.ts
@@ -7,7 +7,7 @@ import { v4 as uuid } from 'uuid';
 import { UnitControlBaseDTO, UnitControlDTO } from '../dtos/unit-control.dto';
 import { UnitControlMap } from '../maps/unit-control.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { UnitControlWorkspaceRepository } from './unit-control.repository';
 
 @Injectable()
@@ -38,7 +38,7 @@ export class UnitControlWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       unitControls.map(async unitControl => {
         const unitControlRecord = await withTransaction(
           this.repository,

--- a/src/unit-fuel-workspace/unit-fuel.service.ts
+++ b/src/unit-fuel-workspace/unit-fuel.service.ts
@@ -165,6 +165,7 @@ export class UnitFuelWorkspaceService {
             payload: unitFuel,
             userId,
             isImport: true,
+            trx,
           });
         }
       }),

--- a/src/unit-fuel-workspace/unit-fuel.service.ts
+++ b/src/unit-fuel-workspace/unit-fuel.service.ts
@@ -8,7 +8,7 @@ import { v4 as uuid } from 'uuid';
 import { UnitFuelBaseDTO, UnitFuelDTO } from '../dtos/unit-fuel.dto';
 import { UnitFuelMap } from '../maps/unit-fuel.map';
 import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-plan.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { UnitFuelWorkspaceRepository } from './unit-fuel.repository';
 
 @Injectable()
@@ -137,7 +137,7 @@ export class UnitFuelWorkspaceService {
     userId: string,
     trx?: EntityManager,
   ) {
-    await Promise.all(
+    await settlePromises(
       unitFuels.map(async unitFuel => {
         const unitFuelRecord = await withTransaction(
           this.repository,

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -11,7 +11,7 @@ import {
 import { UnitStackConfigurationMap } from '../maps/unit-stack-configuration.map';
 import { StackPipeWorkspaceService } from '../stack-pipe-workspace/stack-pipe.service';
 import { UnitService } from '../unit/unit.service';
-import { withTransaction } from '../utils';
+import { settlePromises, withTransaction } from '../utils';
 import { UnitStackConfigurationWorkspaceRepository } from './unit-stack-configuration.repository';
 
 @Injectable()
@@ -126,7 +126,7 @@ export class UnitStackConfigurationWorkspaceService {
   ) {
     const unitStackConfigDTOs: UnitStackConfigurationDTO[] = [];
 
-    await Promise.all(
+    await settlePromises(
       plan.unitStackConfigurationData.map(async unitStackConfig => {
         const stackPipe = await this.stackPipeService.getStackByNameAndFacId(
           unitStackConfig.stackPipeId,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,6 +122,35 @@ export const throwIfErrors = (errorList: string[]) => {
   }
 };
 
+export const settlePromises = async <T>(promises: Array<Promise<T>>) => {
+  const { values, errors } = (await Promise.allSettled(promises)).reduce<{
+    values: T[];
+    errors: any[];
+  }>(
+    (acc, result) => {
+      if (result.status === 'fulfilled')
+        return {
+          ...acc,
+          values: [...acc.values, result.value],
+        };
+      return {
+        ...acc,
+        errors: [...acc.errors, result.reason],
+      };
+    },
+    { values: [], errors: [] },
+  );
+
+  if (errors.length > 0) {
+    throw new EaseyException(
+      new Error(JSON.stringify(errors)),
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+
+  return values;
+};
+
 /**
  * Pass a transaction manager, if it exists, to a custom repository. If not, return the original repository.
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,30 +122,37 @@ export const throwIfErrors = (errorList: string[]) => {
   }
 };
 
+/**
+ * Wrapper around `Promise.allSettled` that throws an error if any promises are rejected (as a JSON stringified array of error messages).
+ */
 export const settlePromises = async <T>(promises: Array<Promise<T>>) => {
   const { values, errors } = (await Promise.allSettled(promises)).reduce<{
     values: T[];
-    errors: any[];
+    errors: unknown[];
   }>(
     (acc, result) => {
-      if (result.status === 'fulfilled')
-        return {
-          ...acc,
-          values: [...acc.values, result.value],
-        };
-      return {
-        ...acc,
-        errors: [...acc.errors, result.reason],
-      };
+      if (result.status === 'fulfilled') {
+        acc.values.push(result.value);
+      } else {
+        let reason = result.reason;
+        try {
+          // If the reason is already a JSON string, parse it.
+          const parsed = JSON.parse(reason.message);
+          // If it's an array, flatten it; otherwise, wrap it in an array.
+          reason = Array.isArray(parsed) ? parsed : [parsed];
+        } catch {
+          // If parsing fails, just store the message as a single-element array.
+          reason = [reason.message];
+        }
+        acc.errors.push(...reason); // Flatten errors into the main array
+      }
+      return acc;
     },
     { values: [], errors: [] },
   );
 
   if (errors.length > 0) {
-    throw new EaseyException(
-      new Error(JSON.stringify(errors)),
-      HttpStatus.BAD_REQUEST,
-    );
+    throw new Error(JSON.stringify(errors));
   }
 
   return values;

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,6 +844,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@pkgr/core@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
+  integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz"
@@ -2723,6 +2728,14 @@ eslint-plugin-import@^2.25.2:
     semver "^6.3.1"
     tsconfig-paths "^3.14.2"
 
+eslint-plugin-prettier@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz#c4af01691a6fa9905207f0fbba0d7bea0902cce5"
+  integrity sha512-qJ+y0FfCp/mQYQ/vWQ3s7eUlFEL4PyKfAJxsnYTJ4YT73nsJBWqmEpFryxV9OeUiqmsTsYJ5Y+KDNaeP31wrRw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+    synckit "^0.9.1"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
@@ -2975,6 +2988,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@^3.2.9:
   version "3.3.2"
@@ -5188,6 +5206,13 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
 prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
@@ -5946,6 +5971,14 @@ symbol-tree@^3.2.4:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synckit@^0.9.1:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.9.2.tgz#a3a935eca7922d48b9e7d6c61822ee6c3ae4ec62"
+  integrity sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==
+  dependencies:
+    "@pkgr/core" "^0.1.0"
+    tslib "^2.6.2"
+
 tapable@^1.0.0:
   version "1.1.3"
   resolved "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz"
@@ -6172,6 +6205,11 @@ tslib@^2.1.0, tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## Related Issues:

[#6621](https://github.com/US-EPA-CAMD/easey-ui/issues/6621)

## Main Changes:

- Created a wrapper function around `Promise.allSettled` that returns the resolved values if all contained promises succeed, and otherwise throws a recursively JSON stringified array of the error messages if any fail.
- Fixed one function call that was not using the parent transaction.
- Updated some function calls that were not using the transaction to instead used the transaction connection, and moved any calls that require original data (i.e. data not modified in the transaction) outside the transaction boundaries.
- Updated deprecated ESLint plugins.