### PR TITLE
To allow MP to begin dates up to 90 days in future. (fix/#6534-allow-future-begin-dates)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@nestjs/testing": "^10.4.7",
     "@types/express": "^4.17.3",
     "@types/jest": "27.0.2",
+    "@types/moment": "^2.13.0",
     "@types/node": "^16.11.2",
     "@types/supertest": "^2.0.8",
     "@types/uuid": "^8.3.1",

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -1,8 +1,8 @@
 import moment from 'moment';
 
-export const MAXIMUM_FUTURE_DATE = moment()
-  .add(90, 'days')
-  .format('YYYY-MM-DD');
+export const getMaximumFutureDate = (): string =>
+  moment().add(90, 'days').format('YYYY-MM-DD');
+export const MAXIMUM_FUTURE_DATE = getMaximumFutureDate();
 export const MINIMUM_DATE = '1993-01-01';
 export const MIN_HOUR = 0;
 export const MAX_HOUR = 23;

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -1,7 +1,7 @@
-const moment = require('moment');
+import moment from 'moment';
 
 export const MAXIMUM_FUTURE_DATE = moment()
-  .add(30, 'days')
+  .add(90, 'days')
   .format('YYYY-MM-DD');
 export const MINIMUM_DATE = '1993-01-01';
 export const MIN_HOUR = 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,6 +1043,13 @@
   resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz"
   integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
 
+"@types/moment@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.npmmirror.com/@types/moment/-/moment-2.13.0.tgz#604ebd189bc3bc34a1548689404e61a2a4aac896"
+  integrity sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==
+  dependencies:
+    moment "*"
+
 "@types/node@*", "@types/node@>=10.0.0", "@types/node@^16.11.2":
   version "16.18.61"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.18.61.tgz"
@@ -4632,6 +4639,11 @@ mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moment@*:
+  version "2.30.1"
+  resolved "https://registry.npmmirror.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moment@^2.29.4:
   version "2.29.4"


### PR DESCRIPTION
### Changes Made:
- Updated backend MAXIMUM_FUTURE_DATE constant from 30 to 90 days
- Modified frontend date picker to allow future date selection up to 90 days for:
    - Defaults
    - Formulas
    - Loads
    - Location Attributes
    - Methods
    - Qualifications
    - Rectangular Duct WAFs
    - Spans
    - Systems
    - Unit Information

### Testing:
- Verify users can select and save begin dates up to 90 days in the future on all specified screens.


```
