### PR TITLE
Fix/6645 timeout errors

### DIFF
--- a/manifest-vars.beta.yml
+++ b/manifest-vars.beta.yml
@@ -2,10 +2,9 @@ instances: 2
 environment: beta
 host: api-easey-beta.app.cloud.gov
 apiHost: api.epa.gov/easey/beta
-maxConnectionPool: 15
+maxConnectionPool: 30
 idleTimeout: 30000
-connectionTimeout: 10000
-acquireConnectionFromPoolTimeout: 15000
+connectionTimeout: 60000
 statementTimeout: 300000
 idleInTransactionSessionTimeout: 300000
 maxUsesBeforeRecreatingConnection: 500

--- a/manifest-vars.perf.yml
+++ b/manifest-vars.perf.yml
@@ -2,10 +2,9 @@ instances: 2
 environment: performance
 host: api-easey-perf.app.cloud.gov
 apiHost: api.epa.gov/easey/perf
-maxConnectionPool: 15
+maxConnectionPool: 30
 idleTimeout: 30000
-connectionTimeout: 10000
-acquireConnectionFromPoolTimeout: 15000
+connectionTimeout: 60000
 statementTimeout: 300000
 idleInTransactionSessionTimeout: 300000
 maxUsesBeforeRecreatingConnection: 500

--- a/manifest-vars.prod.yml
+++ b/manifest-vars.prod.yml
@@ -2,10 +2,9 @@ instances: 2
 environment: production
 host: api-easey.app.cloud.gov
 apiHost: api.epa.gov/easey
-maxConnectionPool: 15
+maxConnectionPool: 30
 idleTimeout: 30000
-connectionTimeout: 10000
-acquireConnectionFromPoolTimeout: 15000
+connectionTimeout: 60000
 statementTimeout: 300000
 idleInTransactionSessionTimeout: 300000
 maxUsesBeforeRecreatingConnection: 500

--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -2,10 +2,9 @@ instances: 2
 environment: staging
 host: api-easey-stg.app.cloud.gov
 apiHost: api.epa.gov/easey/staging
-maxConnectionPool: 5
+maxConnectionPool: 30
 idleTimeout: 5000
-connectionTimeout: 5000
-acquireConnectionFromPoolTimeout: 3000
+connectionTimeout: 60000
 statementTimeout: 200000
 idleInTransactionSessionTimeout: 60000
 maxUsesBeforeRecreatingConnection: 500

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -2,10 +2,9 @@ instances: 1
 environment: testing
 host: api-easey-tst.app.cloud.gov
 apiHost: api.epa.gov/easey/test
-maxConnectionPool: 5
+maxConnectionPool: 30
 idleTimeout: 5000
-connectionTimeout: 5000
-acquireConnectionFromPoolTimeout: 3000
+connectionTimeout: 60000
 statementTimeout: 200000
 idleInTransactionSessionTimeout: 60000
 maxUsesBeforeRecreatingConnection: 500

--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -11,10 +11,9 @@ description: Monitor Plan management API endpoints for all monitor plan data & o
 environment: development
 apiHost: api.epa.gov/easey/dev
 dbSvc: camd-pg-db
-maxConnectionPool: 15
+maxConnectionPool: 30
 idleTimeout: 30000
-connectionTimeout: 10000
-acquireConnectionFromPoolTimeout: 15000
+connectionTimeout: 60000
 statementTimeout: 300000
 idleInTransactionSessionTimeout: 300000
 maxUsesBeforeRecreatingConnection: 500

--- a/manifest.yml
+++ b/manifest.yml
@@ -27,7 +27,6 @@ applications:
       EASEY_DB_MAX_CONNECTION_POOL: ((maxConnectionPool))
       EASEY_DB_IDLE_TIMEOUT: ((idleTimeout))
       EASEY_DB_CONNECTION_TIMEOUT: ((connectionTimeout))
-      EASEY_DB_IDLE_CONNECTION_TIMEOUT: ((acquireConnectionFromPoolTimeout))
       EASEY_DB_STATEMENT_TIMEOUT: ((statementTimeout))
       EASEY_DB_IDLE_TRANS_SESSION_TIMEOUT: ((idleInTransactionSessionTimeout))
       EASEY_DB_MAX_USES_BEFORE_CONN_RECREATE: ((maxUsesBeforeRecreatingConnection))

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -94,7 +94,6 @@ export default registerAs('app', () => ({
   maxConnectionPool: getConfigValueNumber('EASEY_DB_MAX_CONNECTION_POOL',15),
   idleTimeout: getConfigValueNumber( 'EASEY_DB_IDLE_TIMEOUT', 30000, ),
   connectionTimeout: getConfigValueNumber('EASEY_DB_CONNECTION_TIMEOUT',10000),
-  acquireConnectionFromPoolTimeout: getConfigValueNumber('EASEY_DB_IDLE_CONNECTION_TIMEOUT',15000),
   statementTimeout: getConfigValueNumber('EASEY_DB_STATEMENT_TIMEOUT',300000),
   idleInTransactionSessionTimeout: getConfigValueNumber('EASEY_DB_IDLE_TRANS_SESSION_TIMEOUT',300000),
   sqlLogging: getConfigValue('EASEY_DB_SQL_LOGGING', "error"),

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -51,7 +51,6 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
         max: this.configService.get<number>('app.maxConnectionPool'),                                 // Max connections in pool
         idleTimeoutMillis: this.configService.get<number>('app.idleTimeout'),                         // Close idle connections
         connectionTimeoutMillis: this.configService.get<number>('app.connectionTimeout'),             // Maximum time (ms) to wait for a new connection before timing out.
-        acquireTimeoutMillis: this.configService.get<number>('app.acquireConnectionFromPoolTimeout'), // Fail if a connection is not acquired from the pool within timeframe
         statement_timeout: this.configService.get<number>('app.statementTimeout'),                    // Terminates queries that exceed the timeout (in ms).
         idle_in_transaction_session_timeout: this.configService.get<number>('app.idleInTransactionSessionTimeout'), // Terminates idle transactions after the specified time (in ms).
         maxUses: this.configService.get<number>('app.maxUsesBeforeRecreatingConnection'), //Recreate connections after 'n' uses


### PR DESCRIPTION
## Related Issues:

[#6645](https://github.com/US-EPA-CAMD/easey-ui/issues/6645)

## Main Changes:

- Updated the connection timeout and pool size settings to the minimum values necessary to handle large configurations.