### PR TITLE
Update to allow MP import with a future date up to 90 days. (Ref: #6537)

### DIFF
--- a/src/dtos/duct-waf.dto.ts
+++ b/src/dtos/duct-waf.dto.ts
@@ -19,15 +19,16 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import { DATE_FORMAT, MAX_HOUR, MIN_HOUR } from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR, MAXIMUM_FUTURE_DATE } from '../utilities/constants';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 
 const KEY = 'Rectangular Duct Waf';
 const MINIMUM_DATE = '2004-01-01';
-const CURRENT_DATE = () => {
-  return new Date().toISOString().split('T')[0];
-};
-
+// Using MAXIMUM_FUTURE_DATE from constants.ts instead of CURRENT_DATE
+// This allows dates up to 90 days in the future, consistent with other DTOs
+// const CURRENT_DATE = () => {
+//   return new Date().toISOString().split('T')[0];
+// };
 export class DuctWafBaseDTO {
   @ApiProperty({
     description: propertyMetadata.ductWafDTOWafDeterminationDate.description,
@@ -69,7 +70,7 @@ export class DuctWafBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, CURRENT_DATE(), {
+  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-82-B', {
         Fieldname: args.property,
@@ -357,7 +358,7 @@ export class DuctWafBaseDTO {
       return `You reported [wafEndHour] but did not report an [wafEndDate] for [[${KEY}]].`;
     },
   })
-  @IsInDateRange(MINIMUM_DATE, CURRENT_DATE(), {
+  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-84-A', {
         Fieldname: args.property,


### PR DESCRIPTION
### Changes Made: 
- Updated the CURRENT_DATE() function with 'MAXIMUM_FUTURE_DATE'. 
- Which is consistent with other DTOs--allow future dates up to 90 days.  

### Testing: 
Tested import functionality with MP that has a begin date:
- Today
- 30 days in the future
- 90 days in the future
- 91 days in the future (should fail)

### Ref: 
- https://github.com/US-EPA-CAMD/easey-ui/issues/6537
- https://github.com/US-EPA-CAMD/easey-ui/issues/6534