### PR TITLE
Update to allow MP import with a future date up to 90 days.

### DIFF
--- a/src/dtos/analyzer-range.dto.ts
+++ b/src/dtos/analyzer-range.dto.ts
@@ -82,7 +82,7 @@ export class AnalyzerRangeBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-18-B', {
         fieldname: args.property,
@@ -150,7 +150,7 @@ export class AnalyzerRangeBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-20-A', {
         fieldname: args.property,

--- a/src/dtos/analyzer-range.dto.ts
+++ b/src/dtos/analyzer-range.dto.ts
@@ -82,6 +82,7 @@ export class AnalyzerRangeBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-18-B', {

--- a/src/dtos/analyzer-range.dto.ts
+++ b/src/dtos/analyzer-range.dto.ts
@@ -19,13 +19,7 @@ import {
 import { BeginEndDatesConsistent } from '../utils';
 
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MAX_HOUR,
-  MINIMUM_DATE,
-  MIN_HOUR,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MINIMUM_DATE, MIN_HOUR, getMaximumFutureDate } from '../utilities/constants';
 import { AnalyzerRangeCode } from '../entities/analyzer-range-code.entity';
 
 const KEY = 'Analyzer Range';
@@ -88,7 +82,7 @@ export class AnalyzerRangeBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-18-B', {
         fieldname: args.property,
@@ -156,7 +150,7 @@ export class AnalyzerRangeBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-20-A', {
         fieldname: args.property,

--- a/src/dtos/duct-waf.dto.ts
+++ b/src/dtos/duct-waf.dto.ts
@@ -24,7 +24,7 @@ import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 
 const KEY = 'Rectangular Duct Waf';
 const MINIMUM_DATE = '2004-01-01';
-// Using getMaximumFutureDate() from constants.ts instead of CURRENT_DATE
+// Using getMaximumFutureDate() (passed by reference) from constants.ts instead of CURRENT_DATE
 // This allows dates up to 90 days in the future, consistent with other DTOs
 // const CURRENT_DATE = () => {
 //   return new Date().toISOString().split('T')[0];

--- a/src/dtos/duct-waf.dto.ts
+++ b/src/dtos/duct-waf.dto.ts
@@ -70,7 +70,7 @@ export class DuctWafBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-82-B', {
         Fieldname: args.property,
@@ -358,7 +358,7 @@ export class DuctWafBaseDTO {
       return `You reported [wafEndHour] but did not report an [wafEndDate] for [[${KEY}]].`;
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-84-A', {
         Fieldname: args.property,

--- a/src/dtos/duct-waf.dto.ts
+++ b/src/dtos/duct-waf.dto.ts
@@ -19,12 +19,12 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import { DATE_FORMAT, MAX_HOUR, MIN_HOUR, MAXIMUM_FUTURE_DATE } from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR, getMaximumFutureDate } from '../utilities/constants';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 
 const KEY = 'Rectangular Duct Waf';
 const MINIMUM_DATE = '2004-01-01';
-// Using MAXIMUM_FUTURE_DATE from constants.ts instead of CURRENT_DATE
+// Using getMaximumFutureDate() from constants.ts instead of CURRENT_DATE
 // This allows dates up to 90 days in the future, consistent with other DTOs
 // const CURRENT_DATE = () => {
 //   return new Date().toISOString().split('T')[0];
@@ -70,7 +70,7 @@ export class DuctWafBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-82-B', {
         Fieldname: args.property,
@@ -358,7 +358,7 @@ export class DuctWafBaseDTO {
       return `You reported [wafEndHour] but did not report an [wafEndDate] for [[${KEY}]].`;
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-84-A', {
         Fieldname: args.property,

--- a/src/dtos/monitor-attribute.dto.ts
+++ b/src/dtos/monitor-attribute.dto.ts
@@ -18,11 +18,7 @@ import {
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 
 const KEY = 'Monitoring Location Attribute';
@@ -157,7 +153,7 @@ export class MonitorAttributeBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('MONLOC-11-B', {
         fieldname: args.property,
@@ -185,7 +181,7 @@ export class MonitorAttributeBaseDTO {
     example: propertyMetadata.monitorAttributeDTOEndDate.example,
     name: propertyMetadata.monitorAttributeDTOEndDate.fieldLabels.value,
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('MONLOC-12-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-attribute.dto.ts
+++ b/src/dtos/monitor-attribute.dto.ts
@@ -153,7 +153,7 @@ export class MonitorAttributeBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('MONLOC-11-B', {
         fieldname: args.property,
@@ -181,7 +181,7 @@ export class MonitorAttributeBaseDTO {
     example: propertyMetadata.monitorAttributeDTOEndDate.example,
     name: propertyMetadata.monitorAttributeDTOEndDate.fieldLabels.value,
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('MONLOC-12-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-attribute.dto.ts
+++ b/src/dtos/monitor-attribute.dto.ts
@@ -153,6 +153,7 @@ export class MonitorAttributeBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('MONLOC-11-B', {

--- a/src/dtos/monitor-default.dto.ts
+++ b/src/dtos/monitor-default.dto.ts
@@ -292,6 +292,7 @@ export class MonitorDefaultBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-39-B', {

--- a/src/dtos/monitor-default.dto.ts
+++ b/src/dtos/monitor-default.dto.ts
@@ -23,13 +23,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import {
-  DATE_FORMAT,
-  MAX_HOUR,
-  MAXIMUM_FUTURE_DATE,
-  MIN_HOUR,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { FuelCode } from '../entities/fuel-code.entity';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 import { IfIsActive } from '../import-checks/pipes/if-is-active-records.pipe';
@@ -298,7 +292,7 @@ export class MonitorDefaultBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-39-B', {
         fieldname: args.property,
@@ -354,7 +348,7 @@ export class MonitorDefaultBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-41-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-default.dto.ts
+++ b/src/dtos/monitor-default.dto.ts
@@ -292,7 +292,7 @@ export class MonitorDefaultBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-39-B', {
         fieldname: args.property,
@@ -348,7 +348,7 @@ export class MonitorDefaultBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('DEFAULT-41-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-formula.dto.ts
+++ b/src/dtos/monitor-formula.dto.ts
@@ -21,13 +21,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAX_HOUR,
-  MAXIMUM_FUTURE_DATE,
-  MIN_HOUR,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 import { EquationCode } from '../entities/equation-code.entity';
 import { FormulaMdRelationshipsView } from '../entities/formula-md-relationships-view.entity';
@@ -131,7 +125,7 @@ export class MonitorFormulaBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FORMULA-1-B', {
         fieldname: args.property,
@@ -199,7 +193,7 @@ export class MonitorFormulaBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FORMULA-3-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-formula.dto.ts
+++ b/src/dtos/monitor-formula.dto.ts
@@ -125,6 +125,7 @@ export class MonitorFormulaBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FORMULA-1-B', {

--- a/src/dtos/monitor-formula.dto.ts
+++ b/src/dtos/monitor-formula.dto.ts
@@ -125,7 +125,7 @@ export class MonitorFormulaBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FORMULA-1-B', {
         fieldname: args.property,
@@ -193,7 +193,7 @@ export class MonitorFormulaBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FORMULA-3-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-load.dto.ts
+++ b/src/dtos/monitor-load.dto.ts
@@ -170,7 +170,7 @@ export class MonitorLoadBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('LOAD-2-B', {
         fieldname: args.property,
@@ -232,7 +232,7 @@ export class MonitorLoadBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('LOAD-4-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-load.dto.ts
+++ b/src/dtos/monitor-load.dto.ts
@@ -18,13 +18,7 @@ import {
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAX_HOUR,
-  MAXIMUM_FUTURE_DATE,
-  MIN_HOUR,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 
 const KEY = 'Monitoring Load';
@@ -176,7 +170,7 @@ export class MonitorLoadBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('LOAD-2-B', {
         fieldname: args.property,
@@ -238,7 +232,7 @@ export class MonitorLoadBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('LOAD-4-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-load.dto.ts
+++ b/src/dtos/monitor-load.dto.ts
@@ -170,6 +170,7 @@ export class MonitorLoadBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('LOAD-2-B', {

--- a/src/dtos/monitor-method.dto.ts
+++ b/src/dtos/monitor-method.dto.ts
@@ -106,7 +106,7 @@ export class MonitorMethodBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('METHOD-1-B', {
         fieldname: args.property,
@@ -168,7 +168,7 @@ export class MonitorMethodBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('METHOD-3-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-method.dto.ts
+++ b/src/dtos/monitor-method.dto.ts
@@ -106,6 +106,7 @@ export class MonitorMethodBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('METHOD-1-B', {

--- a/src/dtos/monitor-method.dto.ts
+++ b/src/dtos/monitor-method.dto.ts
@@ -19,13 +19,7 @@ import {
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAX_HOUR,
-  MAXIMUM_FUTURE_DATE,
-  MIN_HOUR,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MIN_HOUR, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 
 const KEY = 'Monitoring Method';
@@ -112,7 +106,7 @@ export class MonitorMethodBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('METHOD-1-B', {
         fieldname: args.property,
@@ -174,7 +168,7 @@ export class MonitorMethodBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('METHOD-3-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-qualification.dto.ts
+++ b/src/dtos/monitor-qualification.dto.ts
@@ -27,11 +27,7 @@ import {
 } from './pct-qualification.dto';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 import { IsValidDate } from '@us-epa-camd/easey-common/pipes';
 
@@ -91,7 +87,7 @@ export class MonitorQualificationBaseDTO {
     name: propertyMetadata.monitorQualificationDTOEndDate.fieldLabels.value,
   })
   @ValidateIf(o => o.endDate !== null)
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('QUAL-19-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-qualification.dto.ts
+++ b/src/dtos/monitor-qualification.dto.ts
@@ -87,7 +87,7 @@ export class MonitorQualificationBaseDTO {
     name: propertyMetadata.monitorQualificationDTOEndDate.fieldLabels.value,
   })
   @ValidateIf(o => o.endDate !== null)
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('QUAL-19-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-qualification.dto.ts
+++ b/src/dtos/monitor-qualification.dto.ts
@@ -87,6 +87,7 @@ export class MonitorQualificationBaseDTO {
     name: propertyMetadata.monitorQualificationDTOEndDate.fieldLabels.value,
   })
   @ValidateIf(o => o.endDate !== null)
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('QUAL-19-A', {

--- a/src/dtos/monitor-span.dto.ts
+++ b/src/dtos/monitor-span.dto.ts
@@ -302,7 +302,7 @@ export class MonitorSpanBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SPAN-8-B', {
         fieldname: args.property,
@@ -370,7 +370,7 @@ export class MonitorSpanBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SPAN-10-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-span.dto.ts
+++ b/src/dtos/monitor-span.dto.ts
@@ -22,13 +22,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MAX_HOUR,
-  MINIMUM_DATE,
-  MIN_HOUR,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MINIMUM_DATE, MIN_HOUR, getMaximumFutureDate } from '../utilities/constants';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 import { VwSpanMasterDataRelationships } from '../entities/vw-span-master-data-relationships.entity';
 import { BeginEndDatesConsistent } from '../utils';
@@ -308,7 +302,7 @@ export class MonitorSpanBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SPAN-8-B', {
         fieldname: args.property,
@@ -376,7 +370,7 @@ export class MonitorSpanBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SPAN-10-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-span.dto.ts
+++ b/src/dtos/monitor-span.dto.ts
@@ -302,6 +302,7 @@ export class MonitorSpanBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SPAN-8-B', {

--- a/src/dtos/monitor-system.dto.ts
+++ b/src/dtos/monitor-system.dto.ts
@@ -143,6 +143,7 @@ export class MonitorSystemBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SYSTEM-1-B', {

--- a/src/dtos/monitor-system.dto.ts
+++ b/src/dtos/monitor-system.dto.ts
@@ -143,7 +143,7 @@ export class MonitorSystemBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SYSTEM-1-B', {
         fieldname: args.property,
@@ -187,7 +187,7 @@ export class MonitorSystemBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SYSTEM-3-A', {
         fieldname: args.property,

--- a/src/dtos/monitor-system.dto.ts
+++ b/src/dtos/monitor-system.dto.ts
@@ -28,13 +28,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MAX_HOUR,
-  MINIMUM_DATE,
-  MIN_HOUR,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MINIMUM_DATE, MIN_HOUR, getMaximumFutureDate } from '../utilities/constants';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
 import { SystemTypeCode } from '../entities/system-type-code.entity';
 import { BeginEndDatesConsistent } from '../utils';
@@ -149,7 +143,7 @@ export class MonitorSystemBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SYSTEM-1-B', {
         fieldname: args.property,
@@ -193,7 +187,7 @@ export class MonitorSystemBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('SYSTEM-3-A', {
         fieldname: args.property,

--- a/src/dtos/system-component.dto.ts
+++ b/src/dtos/system-component.dto.ts
@@ -64,7 +64,7 @@ export class SystemComponentBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-3-B', {
         fieldname: args.property,
@@ -132,7 +132,7 @@ export class SystemComponentBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-5-A', {
         fieldname: args.property,

--- a/src/dtos/system-component.dto.ts
+++ b/src/dtos/system-component.dto.ts
@@ -64,6 +64,7 @@ export class SystemComponentBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-3-B', {

--- a/src/dtos/system-component.dto.ts
+++ b/src/dtos/system-component.dto.ts
@@ -22,13 +22,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MAX_HOUR,
-  MINIMUM_DATE,
-  MIN_HOUR,
-} from '../utilities/constants';
+import { DATE_FORMAT, MAX_HOUR, MINIMUM_DATE, MIN_HOUR, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 
 const KEY = 'System Component';
@@ -70,7 +64,7 @@ export class SystemComponentBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-3-B', {
         fieldname: args.property,
@@ -138,7 +132,7 @@ export class SystemComponentBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('COMPON-5-A', {
         fieldname: args.property,

--- a/src/dtos/system-fuel-flow.dto.ts
+++ b/src/dtos/system-fuel-flow.dto.ts
@@ -136,7 +136,7 @@ export class SystemFuelFlowBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUELFLW-3-B', {
         fieldname: args.property,
@@ -197,7 +197,7 @@ export class SystemFuelFlowBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUELFLW-5-A', {
         fieldname: args.property,

--- a/src/dtos/system-fuel-flow.dto.ts
+++ b/src/dtos/system-fuel-flow.dto.ts
@@ -19,13 +19,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-import {
-  MINIMUM_DATE,
-  MAXIMUM_FUTURE_DATE,
-  MAX_HOUR,
-  MIN_HOUR,
-  DATE_FORMAT,
-} from '../utilities/constants';
+import { MINIMUM_DATE, MAX_HOUR, MIN_HOUR, DATE_FORMAT, getMaximumFutureDate } from '../utilities/constants';
 import { SystemFuelMasterDataRelationship } from '../entities/system-fuel-md-relationship.entity';
 import { FindManyOptions } from 'typeorm';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
@@ -142,7 +136,7 @@ export class SystemFuelFlowBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUELFLW-3-B', {
         fieldname: args.property,
@@ -203,7 +197,7 @@ export class SystemFuelFlowBaseDTO {
       });
     },
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUELFLW-5-A', {
         fieldname: args.property,

--- a/src/dtos/system-fuel-flow.dto.ts
+++ b/src/dtos/system-fuel-flow.dto.ts
@@ -136,6 +136,7 @@ export class SystemFuelFlowBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUELFLW-3-B', {

--- a/src/dtos/unit-capacity.dto.ts
+++ b/src/dtos/unit-capacity.dto.ts
@@ -61,7 +61,7 @@ export class UnitCapacityBaseDTO {
       });
     },
   })
-  @IsInDateRange('1930-01-01', getMaximumFutureDate(), {
+  @IsInDateRange('1930-01-01', getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CAPAC-5-B', {
         fieldname: args.property,
@@ -90,7 +90,7 @@ export class UnitCapacityBaseDTO {
     name: propertyMetadata.unitCapacityDTOEndDate.fieldLabels.value,
   })
   @IsOptional()
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CAPAC-2-A', {
         fieldname: args.property,

--- a/src/dtos/unit-capacity.dto.ts
+++ b/src/dtos/unit-capacity.dto.ts
@@ -16,11 +16,7 @@ import {
 } from 'class-validator';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 
 const KEY = 'Unit Capacity';
@@ -65,7 +61,7 @@ export class UnitCapacityBaseDTO {
       });
     },
   })
-  @IsInDateRange('1930-01-01', MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange('1930-01-01', getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CAPAC-5-B', {
         fieldname: args.property,
@@ -94,7 +90,7 @@ export class UnitCapacityBaseDTO {
     name: propertyMetadata.unitCapacityDTOEndDate.fieldLabels.value,
   })
   @IsOptional()
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CAPAC-2-A', {
         fieldname: args.property,

--- a/src/dtos/unit-capacity.dto.ts
+++ b/src/dtos/unit-capacity.dto.ts
@@ -61,6 +61,7 @@ export class UnitCapacityBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange('1930-01-01', getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CAPAC-5-B', {

--- a/src/dtos/unit-control.dto.ts
+++ b/src/dtos/unit-control.dto.ts
@@ -100,7 +100,7 @@ export class UnitControlBaseDTO {
       return `The value for [${args.value}] in the Unit Control record [${args.property}] must be a valid ISO date format [${DATE_FORMAT}]`;
     },
   })
-  @IsInDateRange('1930-01-01', getMaximumFutureDate(), {
+  @IsInDateRange('1930-01-01', getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CONTROL-5-B', {
         fieldname: args.property,
@@ -160,7 +160,7 @@ export class UnitControlBaseDTO {
     name: propertyMetadata.unitControlDTORetireDate.fieldLabels.value,
   })
   @IsOptional()
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CONTROL-6-A', {
         fieldname: args.property,

--- a/src/dtos/unit-control.dto.ts
+++ b/src/dtos/unit-control.dto.ts
@@ -17,11 +17,7 @@ import {
 } from '@us-epa-camd/easey-common/pipes';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { VwUnitcontrolMasterDataRelationships } from '../entities/vw-unitcontrol-master-data-relationships.entity';
 import { ControlCode } from '../entities/control-code.entity';
 
@@ -104,7 +100,7 @@ export class UnitControlBaseDTO {
       return `The value for [${args.value}] in the Unit Control record [${args.property}] must be a valid ISO date format [${DATE_FORMAT}]`;
     },
   })
-  @IsInDateRange('1930-01-01', MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange('1930-01-01', getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CONTROL-5-B', {
         fieldname: args.property,
@@ -164,7 +160,7 @@ export class UnitControlBaseDTO {
     name: propertyMetadata.unitControlDTORetireDate.fieldLabels.value,
   })
   @IsOptional()
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CONTROL-6-A', {
         fieldname: args.property,

--- a/src/dtos/unit-control.dto.ts
+++ b/src/dtos/unit-control.dto.ts
@@ -100,6 +100,7 @@ export class UnitControlBaseDTO {
       return `The value for [${args.value}] in the Unit Control record [${args.property}] must be a valid ISO date format [${DATE_FORMAT}]`;
     },
   })
+  //passed by reference
   @IsInDateRange('1930-01-01', getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('CONTROL-5-B', {

--- a/src/dtos/unit-fuel.dto.ts
+++ b/src/dtos/unit-fuel.dto.ts
@@ -18,11 +18,7 @@ import {
 import { IsInDbValues } from '../import-checks/pipes/is-in-db-values.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInDateRange } from '../import-checks/pipes/is-in-date-range.pipe';
-import {
-  DATE_FORMAT,
-  MAXIMUM_FUTURE_DATE,
-  MINIMUM_DATE,
-} from '../utilities/constants';
+import { DATE_FORMAT, MINIMUM_DATE, getMaximumFutureDate } from '../utilities/constants';
 import { BeginEndDatesConsistent } from '../utils';
 
 const KEY = 'Unit Fuel';
@@ -119,7 +115,7 @@ export class UnitFuelBaseDTO {
       });
     },
   })
-  @IsInDateRange('1930-01-01', MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange('1930-01-01', getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUEL-42-B', {
         fieldname: args.property,
@@ -147,7 +143,7 @@ export class UnitFuelBaseDTO {
     example: propertyMetadata.unitFuelDTOEndDate.example,
     name: propertyMetadata.unitFuelDTOEndDate.fieldLabels.value,
   })
-  @IsInDateRange(MINIMUM_DATE, MAXIMUM_FUTURE_DATE, {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUEL-43-A', {
         fieldname: args.property,

--- a/src/dtos/unit-fuel.dto.ts
+++ b/src/dtos/unit-fuel.dto.ts
@@ -115,7 +115,7 @@ export class UnitFuelBaseDTO {
       });
     },
   })
-  @IsInDateRange('1930-01-01', getMaximumFutureDate(), {
+  @IsInDateRange('1930-01-01', getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUEL-42-B', {
         fieldname: args.property,
@@ -143,7 +143,7 @@ export class UnitFuelBaseDTO {
     example: propertyMetadata.unitFuelDTOEndDate.example,
     name: propertyMetadata.unitFuelDTOEndDate.fieldLabels.value,
   })
-  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate(), {
+  @IsInDateRange(MINIMUM_DATE, getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUEL-43-A', {
         fieldname: args.property,

--- a/src/dtos/unit-fuel.dto.ts
+++ b/src/dtos/unit-fuel.dto.ts
@@ -115,6 +115,7 @@ export class UnitFuelBaseDTO {
       });
     },
   })
+  //passed by reference
   @IsInDateRange('1930-01-01', getMaximumFutureDate, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('FUEL-42-B', {

--- a/src/import-checks/pipes/is-in-date-range.pipe.ts
+++ b/src/import-checks/pipes/is-in-date-range.pipe.ts
@@ -5,28 +5,34 @@ import {
 } from 'class-validator';
 
 export function IsInDateRange(
-  minDate: string,
-  maxDate?: string,
+  minDate: string | (() => string),
+  maxDate: string | (() => string),
   validationOptions?: ValidationOptions,
 ) {
-  return function(object: Object, propertyName: string) {
+  return function (object: Object, propertyName: string): void {
     registerDecorator({
       name: 'isInDateRange',
       target: object.constructor,
       propertyName: propertyName,
       options: validationOptions,
       validator: {
-        validate(value: any, _args: ValidationArguments) {
-          if (value) {
-            const dateObject = new Date(value);
-            const minDateDate = new Date(minDate);
-            const maxDateDate =
-              maxDate !== undefined && maxDate !== null
-                ? new Date(maxDate)
-                : new Date();
-            return dateObject >= minDateDate && dateObject <= maxDateDate;
-          }
-          return true;
+        validate(value: any, args: ValidationArguments): boolean {
+          // Resolve min/max values if functions
+          const min = typeof minDate === 'function' ? minDate() : minDate;
+          const max = typeof maxDate === 'function' ? maxDate() : maxDate;
+
+          // Parse to Date objects
+          const minDateObj = min ? new Date(min) : null;
+          const maxDateObj = max ? new Date(max) : null;
+          const inputDate = value ? new Date(value) : null;
+
+          // Allow empty/null values to pass
+          if (!inputDate || isNaN(inputDate.getTime())) return true;
+
+          const isAfterMin = !minDateObj || inputDate >= minDateObj;
+          const isBeforeMax = !maxDateObj || inputDate <= maxDateObj;
+
+          return isAfterMin && isBeforeMax;
         },
       },
     });

--- a/src/mats-method-workspace/mats-method-checks.service.spec.ts
+++ b/src/mats-method-workspace/mats-method-checks.service.spec.ts
@@ -69,7 +69,7 @@ describe('Mats Method Checks Service Test', () => {
 
       payload.beginDate = new Date('2023-02-28');
       payload.beginHour = 5;
-      payload.endDate = moment(getMaximumFutureDate()).add(1, 'days');
+      payload.endDate = moment(getMaximumFutureDate).add(1, 'days');
       payload.endHour = 1;
 
       let errored = false;

--- a/src/mats-method-workspace/mats-method-checks.service.spec.ts
+++ b/src/mats-method-workspace/mats-method-checks.service.spec.ts
@@ -69,7 +69,7 @@ describe('Mats Method Checks Service Test', () => {
 
       payload.beginDate = new Date('2023-02-28');
       payload.beginHour = 5;
-      payload.endDate = moment(getMaximumFutureDate).add(1, 'days');
+      payload.endDate = moment(getMaximumFutureDate()).add(1, 'days').toDate();
       payload.endHour = 1;
 
       let errored = false;

--- a/src/mats-method-workspace/mats-method-checks.service.spec.ts
+++ b/src/mats-method-workspace/mats-method-checks.service.spec.ts
@@ -4,7 +4,7 @@ import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 
 import { MatsMethodChecksService } from './mats-method-checks.service';
 import { MatsMethodBaseDTO } from '../dtos/mats-method.dto';
-import { MAXIMUM_FUTURE_DATE } from '../utilities/constants';
+import { getMaximumFutureDate } from '../utilities/constants';
 const moment = require('moment');
 
 jest.mock('@us-epa-camd/easey-common/check-catalog');
@@ -69,7 +69,7 @@ describe('Mats Method Checks Service Test', () => {
 
       payload.beginDate = new Date('2023-02-28');
       payload.beginHour = 5;
-      payload.endDate = moment(MAXIMUM_FUTURE_DATE).add(1, 'days');
+      payload.endDate = moment(getMaximumFutureDate()).add(1, 'days');
       payload.endHour = 1;
 
       let errored = false;

--- a/src/mats-method-workspace/mats-method-checks.service.ts
+++ b/src/mats-method-workspace/mats-method-checks.service.ts
@@ -70,7 +70,7 @@ export class MatsMethodChecksService {
 
       if (beginDate && endDate.isBefore(beginDate)) {
         error = this.getMessage('MATSMTH-3-A');
-      } else if (endDate.isAfter(moment(getMaximumFutureDate()))) {
+      } else if (endDate.isAfter(moment(getMaximumFutureDate))) {
         error = this.getMessage('MATSMTH-3-B');
       }
     }

--- a/src/mats-method-workspace/mats-method-checks.service.ts
+++ b/src/mats-method-workspace/mats-method-checks.service.ts
@@ -70,7 +70,7 @@ export class MatsMethodChecksService {
 
       if (beginDate && endDate.isBefore(beginDate)) {
         error = this.getMessage('MATSMTH-3-A');
-      } else if (endDate.isAfter(moment(getMaximumFutureDate))) {
+      } else if (endDate.isAfter(moment(getMaximumFutureDate()))) {
         error = this.getMessage('MATSMTH-3-B');
       }
     }

--- a/src/mats-method-workspace/mats-method-checks.service.ts
+++ b/src/mats-method-workspace/mats-method-checks.service.ts
@@ -2,7 +2,7 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
-import { MAXIMUM_FUTURE_DATE } from '../utilities/constants';
+import { getMaximumFutureDate } from '../utilities/constants';
 import { MatsMethodBaseDTO, MatsMethodDTO } from '../dtos/mats-method.dto';
 
 const moment = require('moment');
@@ -70,7 +70,7 @@ export class MatsMethodChecksService {
 
       if (beginDate && endDate.isBefore(beginDate)) {
         error = this.getMessage('MATSMTH-3-A');
-      } else if (MAXIMUM_FUTURE_DATE && endDate.isAfter(MAXIMUM_FUTURE_DATE)) {
+      } else if (endDate.isAfter(moment(getMaximumFutureDate()))) {
         error = this.getMessage('MATSMTH-3-B');
       }
     }

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 export const getMaximumFutureDate = (): string =>
   moment().add(90, 'days').format('YYYY-MM-DD');
-export const MAXIMUM_FUTURE_DATE = getMaximumFutureDate();
+export const MAXIMUM_FUTURE_DATE = getMaximumFutureDate;
 export const MINIMUM_DATE = '1993-01-01';
 export const MIN_HOUR = 0;
 export const MAX_HOUR = 23;


### PR DESCRIPTION
### Changes Made:
- Updated the 'MAXIMUM_FUTURE_DATE' to a function 'getMaximumFutureDate()'. 
- Updated specific DTOs--allow future dates up to 90 days. 

### Testing:
Tested import functionality with MP that has a future date:
- Today
- 30 days in the future
- 90 days in the future
- 91 days in the future (should fail)

Ref:
https://github.com/US-EPA-CAMD/easey-ui/issues/6537
https://github.com/US-EPA-CAMD/easey-ui/issues/6534