### PR TITLE
Feature/6852 single unit endpoint

### DIFF
--- a/src/unit-workspace/unit.controller.spec.ts
+++ b/src/unit-workspace/unit.controller.spec.ts
@@ -13,9 +13,7 @@ jest.mock('./unit.service');
 
 const unitId = 1;
 
-const data: UnitDTO[] = [];
-data.push(new UnitDTO());
-data.push(new UnitDTO());
+const data = new UnitDTO();
 
 describe('UnitWorkspaceController', () => {
   let controller: UnitWorkspaceController;
@@ -46,8 +44,8 @@ describe('UnitWorkspaceController', () => {
 
   describe('getUnits', () => {
     it('should return array of workspace units', async () => {
-      jest.spyOn(service, 'getUnits').mockResolvedValue(data);
-      expect(await controller.getUnits(unitId)).toStrictEqual({ items: data });
+      jest.spyOn(service, 'getUnit').mockResolvedValue(data);
+      expect(await controller.getUnit(unitId)).toStrictEqual(data);
     });
   });
 

--- a/src/unit-workspace/unit.controller.ts
+++ b/src/unit-workspace/unit.controller.ts
@@ -1,13 +1,21 @@
 import { Body, Controller, Get, Param, Put } from '@nestjs/common';
-import { ApiTags, ApiOkResponse, ApiSecurity, ApiExtraModels, getSchemaPath } from '@nestjs/swagger';
-import { AuditLog, RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiSecurity,
+  ApiExtraModels,
+} from '@nestjs/swagger';
+import {
+  AuditLog,
+  RoleGuard,
+  User,
+} from '@us-epa-camd/easey-common/decorators';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 
 import { UnitWorkspaceService } from './unit.service';
 import { UnitBaseDTO, UnitDTO } from '../dtos/unit.dto';
 import { ApiExcludeControllerByEnv } from '../decorators/swagger-decorator';
-import { ArrayResponse } from '@us-epa-camd/easey-common/interfaces/common.interface';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -19,21 +27,8 @@ export class UnitWorkspaceController {
 
   @Get(':id')
   @ApiOkResponse({
-    description:
-      'Retrieves workspace unit for a specific unit ID',
-    content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              items: {
-                type: 'array',
-                items: { $ref: getSchemaPath(UnitDTO) },
-              },
-            },
-          },
-        },
-      }
+    description: 'Retrieves workspace unit for a specific unit ID',
+    type: UnitDTO,
   })
   @RoleGuard(
     {
@@ -47,10 +42,8 @@ export class UnitWorkspaceController {
     label: 'Retrieved workspace monitor location unit',
     requestParamsOutFields: ['locId', 'id'],
   })
-  async getUnits(@Param('id') unitId: number): Promise<ArrayResponse<UnitDTO>> {
-    const unitDTOS = await this.service.getUnits(unitId);
-
-    return { items: unitDTOS };
+  async getUnit(@Param('id') unitId: number): Promise<UnitDTO> {
+    return this.service.getUnit(unitId);
   }
 
   @Put(':id')

--- a/src/unit-workspace/unit.service.spec.ts
+++ b/src/unit-workspace/unit.service.spec.ts
@@ -9,6 +9,9 @@ import { MonitorPlanWorkspaceService } from '../monitor-plan-workspace/monitor-p
 import { UnitWorkspaceRepository } from './unit.repository';
 import { UnitWorkspaceService } from './unit.service';
 
+const unit = new Unit();
+const unitDto = new UnitDTO();
+
 const mockMap = () => ({
   many: jest.fn().mockResolvedValue([]),
 });
@@ -20,7 +23,7 @@ const mockRepository = () => ({
 
 const mockEntityManager = () => ({
   findOneBy: jest.fn().mockResolvedValue(new MonitorLocation()),
-  query: jest.fn().mockResolvedValue([]),
+  query: jest.fn().mockResolvedValue([unitDto]),
 });
 
 describe('UnitWorkspaceService', () => {
@@ -60,24 +63,20 @@ describe('UnitWorkspaceService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getUnits', () => {
-    it('should return an array of units', async () => {
-      const result = await service.getUnits(1);
-      expect(result).toEqual([]);
+  describe('getUnit', () => {
+    it('should return a single unit', async () => {
+      const result = await service.getUnit(1);
+      expect(result).toEqual(unitDto);
     });
   });
 
   describe('updateUnit', () => {
     it('should return the updated unit', async () => {
       const payload = new UnitBaseDTO();
-      const unit: Unit = new Unit();
-      const unitDetails: UnitDTO[] = [new UnitDTO(), new UnitDTO()]; // Mocked UnitDTO array
 
       jest.spyOn(repository, 'findOneBy').mockResolvedValue(unit);
       jest.spyOn(repository, 'save').mockResolvedValue(unit);
-      jest
-        .spyOn(service as any, 'getUnitDetails')
-        .mockResolvedValue(unitDetails);
+      jest.spyOn(service as any, 'getUnitDetails').mockResolvedValue(unitDto);
 
       const result = await service.updateUnit(1, payload, 'userId');
 
@@ -85,7 +84,7 @@ describe('UnitWorkspaceService', () => {
       expect(service['getUnitDetails']).toHaveBeenCalledWith(1);
 
       // Check if the result is the first element of the mocked UnitDTO array
-      expect(result).toBe(unitDetails[0]);
+      expect(result).toBe(unitDto);
     });
   });
 });

--- a/src/unit-workspace/unit.service.ts
+++ b/src/unit-workspace/unit.service.ts
@@ -19,8 +19,8 @@ export class UnitWorkspaceService {
     private readonly mpService: MonitorPlanWorkspaceService,
   ) {}
 
-  async getUnits(unitId: number): Promise<UnitDTO[]> {
-    return await this.getUnitDetails(unitId);
+  async getUnit(unitId: number): Promise<UnitDTO> {
+    return this.getUnitDetails(unitId);
   }
 
   async updateUnit(
@@ -41,11 +41,10 @@ export class UnitWorkspaceService {
     });
     await this.mpService.resetToNeedsEvaluation(location?.id, userId);
 
-    const unitDetails = await this.getUnitDetails(unitId);
-    return unitDetails && unitDetails.length > 0 ? unitDetails[0] : null;
+    return this.getUnitDetails(unitId);
   }
 
-  private async getUnitDetails(unitId: number): Promise<UnitDTO[]> {
+  private async getUnitDetails(unitId: number): Promise<UnitDTO> {
     const sql = `
         SELECT
             unt.UNIT_ID as "id",
@@ -91,7 +90,7 @@ export class UnitWorkspaceService {
     `;
 
     const result = await this.entityManager.query(sql, [unitId]);
-    return result;
+    return result.pop() || null; // The query returns at most one row, so we can safely use pop() to get the result or null if empty
   }
 
   async getUnitsByFacId(facId: number, trx?: EntityManager) {

--- a/src/unit/unit.controller.spec.ts
+++ b/src/unit/unit.controller.spec.ts
@@ -8,9 +8,7 @@ jest.mock('./unit.service');
 
 const unitId = 1;
 
-const data: UnitDTO[] = [];
-data.push(new UnitDTO());
-data.push(new UnitDTO());
+const data = new UnitDTO();
 
 describe('UnitController', () => {
   let controller: UnitController;
@@ -33,8 +31,8 @@ describe('UnitController', () => {
 
   describe('getUnits', () => {
     it('should return array of units', async () => {
-      jest.spyOn(service, 'getUnits').mockResolvedValue(data);
-      expect(await controller.getUnits(unitId)).toStrictEqual({ items: data} );
+      jest.spyOn(service, 'getUnit').mockResolvedValue(data);
+      expect(await controller.getUnit(unitId)).toStrictEqual(data);
     });
   });
 });

--- a/src/unit/unit.controller.ts
+++ b/src/unit/unit.controller.ts
@@ -1,8 +1,12 @@
 import { Controller, Get, Param } from '@nestjs/common';
-import { ApiOkResponse, ApiSecurity, ApiTags, ApiExtraModels, getSchemaPath } from '@nestjs/swagger';
+import {
+  ApiOkResponse,
+  ApiSecurity,
+  ApiTags,
+  ApiExtraModels,
+} from '@nestjs/swagger';
 import { UnitService } from './unit.service';
 import { UnitDTO } from '../dtos/unit.dto';
-import { ArrayResponse } from '@us-epa-camd/easey-common/interfaces/common.interface';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -13,26 +17,10 @@ export class UnitController {
 
   @Get(':id')
   @ApiOkResponse({
-    description: 'Retrieves unit records from a specific unit ID',
-    content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              items: {
-                type: 'array',
-                items: { $ref: getSchemaPath(UnitDTO) },
-              },
-            },
-          },
-        },
-      }
+    description: 'Retrieves unit record for a specific unit ID',
+    type: UnitDTO,
   })
-  async getUnits(@Param('id') id: number): Promise<ArrayResponse<UnitDTO>> {
-    const units = await this.service.getUnits(id);
-
-    return  {
-      items: units
-    };
+  async getUnit(@Param('id') id: number): Promise<UnitDTO> {
+    return this.service.getUnit(id);
   }
 }

--- a/src/unit/unit.service.spec.ts
+++ b/src/unit/unit.service.spec.ts
@@ -20,7 +20,7 @@ const mockRepository = () => ({
 });
 
 const mockEntityManager = () => ({
-  query: jest.fn().mockResolvedValue([]),
+  query: jest.fn().mockResolvedValue([unit]),
 });
 
 describe('UnitWorkspaceService', () => {
@@ -55,8 +55,8 @@ describe('UnitWorkspaceService', () => {
 
   describe('getUnits', () => {
     it('should return an array of units', async () => {
-      const result = await service.getUnits(1);
-      expect(result).toEqual([]);
+      const result = await service.getUnit(1);
+      expect(result).toEqual(unit);
     });
   });
 

--- a/src/unit/unit.service.ts
+++ b/src/unit/unit.service.ts
@@ -19,7 +19,7 @@ export class UnitService {
     this.logger.setContext('UnitService');
   }
 
-  async getUnits(unitId: number): Promise<UnitDTO[]> {
+  async getUnit(unitId: number): Promise<UnitDTO> {
     return this.getUnitDetails(unitId);
   }
 
@@ -73,7 +73,7 @@ export class UnitService {
     });
   }
 
-  private async getUnitDetails(id: number): Promise<UnitDTO[]> {
+  private async getUnitDetails(id: number): Promise<UnitDTO> {
     const sql = `
         SELECT
             unt.UNIT_ID as "id",
@@ -119,6 +119,6 @@ export class UnitService {
     `;
 
     const result = await this.entityManager.query(sql, [id]);
-    return result;
+    return result.pop() || null; // The query returns at most one row, so we can safely use pop() to get the result or null if empty
   }
 }


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6852

## Main changes:

- Updated the `monitor-plan-mgmt/[workspace/]units/:id` endpoint to return a single object representing a unit, rather than an object with an array of items.

## NOTE:

This branch was forked from [feature/6790-unnecessary_locid_parameter](https://github.com/US-EPA-CAMD/easey-monitor-plan-api/pull/677), so either this PR should be merged into that branch first, or this PR should be retargeted to `develop` and merged second.