### PR TITLE
fix/#6785 Display Correct Data Match Type Dropdown with Data - Fix

### DIFF
--- a/src/monitor-configurations-workspace/monitor-configurations-workspace.controller.spec.ts
+++ b/src/monitor-configurations-workspace/monitor-configurations-workspace.controller.spec.ts
@@ -1,23 +1,45 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 import { DataSource } from 'typeorm';
+import { ForbiddenException } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
 
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
 import { MonitorConfigurationsWorkspaceService } from './monitor-configurations-workspace.service';
 import { MonitorConfigurationsWorkspaceController } from './monitor-configurations-workspace.controller';
 import { ConfigurationMultipleParamsDTO } from '../dtos/configuration-multiple-params.dto';
-import { ConfigService } from '@nestjs/config';
-import { HttpModule } from '@nestjs/axios';
 import { ArrayResponse } from '@us-epa-camd/easey-common/interfaces/common.interface';
+import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { UserRole } from '@us-epa-camd/easey-common/enums';
 
 jest.mock('./monitor-configurations-workspace.service');
+jest.mock('@us-epa-camd/easey-common/guards');
 
-const data: MonitorPlanDTO[] = [];
-data.push(new MonitorPlanDTO());
-data.push(new MonitorPlanDTO());
-
+const data: MonitorPlanDTO[] = [new MonitorPlanDTO(), new MonitorPlanDTO()];
 const mockArrayResponse: ArrayResponse<MonitorPlanDTO> = {
   items: data,
+};
+
+const adminUser: CurrentUser = {
+  userId: 'admin',
+  sessionId: '',
+  expiration: '',
+  clientIp: '',
+  facilities: [],
+  roles: [UserRole.ADMIN],
+};
+
+const nonAdminUser: CurrentUser = {
+  userId: 'testuser',
+  sessionId: '',
+  expiration: '',
+  clientIp: '',
+  facilities: [
+    { facId: 1, orisCode: 3, permissions: [] },
+    { facId: 2, orisCode: 7, permissions: [] },
+  ],
+  roles: [],
 };
 
 describe('MonitorConfigurations', () => {
@@ -49,15 +71,51 @@ describe('MonitorConfigurations', () => {
   describe('getAllConfigurations', () => {
     it('should return array of all monitor plan configurations', async () => {
       jest.spyOn(service, 'getAllConfigurations').mockResolvedValue(data);
-      expect(await controller.getAllConfigurations()).toStrictEqual(mockArrayResponse);
+      expect(await controller.getAllConfigurations()).toStrictEqual(
+        mockArrayResponse,
+      );
     });
   });
 
   describe('getConfigurations', () => {
-    it('should return array of monitor plan configurations', async () => {
-      jest.spyOn(service, 'getConfigurations').mockResolvedValue(data);
+    it('should allow an Admin user to access any requested facility', async () => {
       const dto = new ConfigurationMultipleParamsDTO();
-      expect(await controller.getConfigurations(dto)).toStrictEqual({ items: data});
+      dto.orisCodes = [3, 99];
+      jest.spyOn(service, 'getConfigurations').mockResolvedValue(data);
+
+      const result = await controller.getConfigurations(dto, adminUser);
+
+      expect(service.getConfigurations).toHaveBeenCalledWith(dto.orisCodes, dto.monPlanIds);
+      expect(result).toStrictEqual({ items: data });
     });
+
+    it('should allow a non-Admin user with correct permissions for all requested facilities', async () => {
+      const dto = new ConfigurationMultipleParamsDTO();
+      dto.orisCodes = [3, 7];
+      jest.spyOn(service, 'getConfigurations').mockResolvedValue(data);
+
+      const result = await controller.getConfigurations(dto, nonAdminUser);
+
+      expect(service.getConfigurations).toHaveBeenCalledWith(dto.orisCodes, dto.monPlanIds);
+      expect(result).toStrictEqual({ items: data });
+    });
+
+    it('should throw a ForbiddenException for a non-Admin user requesting a facility without permission', async () => {
+      const dto = new ConfigurationMultipleParamsDTO();
+      dto.orisCodes = [3, 99];
+
+      await expect(
+        controller.getConfigurations(dto, nonAdminUser),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw a ForbiddenException if any of the requested facilities are not in permission list of the user', async () => {
+        const dto = new ConfigurationMultipleParamsDTO();
+        dto.orisCodes = [99, 7];
+  
+        await expect(
+          controller.getConfigurations(dto, nonAdminUser),
+        ).rejects.toThrow(ForbiddenException);
+      });
   });
 });

--- a/src/monitor-configurations-workspace/monitor-configurations-workspace.controller.ts
+++ b/src/monitor-configurations-workspace/monitor-configurations-workspace.controller.ts
@@ -1,13 +1,15 @@
-import { Get, Controller, Query } from '@nestjs/common';
-import { AuditLog, RoleGuard } from '@us-epa-camd/easey-common/decorators';
+import { Get, Controller, Query, UseGuards, ForbiddenException } from '@nestjs/common';
+import { AuditLog, RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
 import { ApiTags, ApiOkResponse, ApiSecurity, ApiQuery, ApiExtraModels, getSchemaPath } from '@nestjs/swagger';
-import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { LookupType, UserRole } from '@us-epa-camd/easey-common/enums';
 import { ConfigurationMultipleParamsDTO } from '../dtos/configuration-multiple-params.dto';
 
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
 import { MonitorConfigurationsWorkspaceService } from './monitor-configurations-workspace.service';
 import { ApiExcludeControllerByEnv } from '../decorators/swagger-decorator';
 import { ArrayResponse } from '@us-epa-camd/easey-common/interfaces/common.interface';
+import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { AuthGuard } from '@us-epa-camd/easey-common/guards';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -34,6 +36,7 @@ export class MonitorConfigurationsWorkspaceController {
         },
       }
   })
+  @RoleGuard({ requiredRoles: [UserRole.ADMIN] }, LookupType.MonitorPlan) 
   @AuditLog({
     label: 'Retrieved all the workspace configurations',
   })
@@ -46,6 +49,7 @@ export class MonitorConfigurationsWorkspaceController {
   }
 
   @Get()
+  @UseGuards(AuthGuard)
   @ApiOkResponse({
     description: 'Retrieves workspace Monitor Plan configurations',
     content: {
@@ -74,21 +78,24 @@ export class MonitorConfigurationsWorkspaceController {
     required: false,
     explode: false,
   })
-  @RoleGuard(
-    {
-      queryParam: 'orisCodes',
-      isPipeDelimitted: true,
-      enforceEvalSubmitCheck: false,
-    },
-    LookupType.Facility,
-  )
   @AuditLog({
     label: 'Retrieved workspace configurations',
     requestQueryOutFields: ['orisCodes', 'monPlanIds']
   })
   async getConfigurations(
     @Query() dto: ConfigurationMultipleParamsDTO,
+    @User() user: CurrentUser,
   ): Promise<ArrayResponse<MonitorPlanDTO>> {
+    if (!user.roles.includes(UserRole.ADMIN)) {
+      const userAllowedOrisCodes = new Set(user.facilities.map(f => f.orisCode));
+      let hasAllPermissions = dto.orisCodes.every(requestedCode => 
+        userAllowedOrisCodes.has(requestedCode)
+      );
+      if (!hasAllPermissions) {
+        throw new ForbiddenException('You do not have permission to access one or more of the requested facilities.');
+      }
+    }
+    
     const monitorPlanDTOs = await this.service.getConfigurations(dto.orisCodes, dto.monPlanIds);
 
     return  {


### PR DESCRIPTION
## Related Ticket:

- ticket [#6785](https://github.com/US-EPA-CAMD/easey-ui/issues/6785)

## Updates:

- Added RoleGuard on endpoint /workspace/configurations/all to only grant ECMPS admin user access.
- Update the logic for /workspace/configurations/ endpoint to grant user with ECMPS admin role full access, while check the permissions for non-admin users.
- Updated related tests.