### PR TITLE
Update anyOf Location Lookup Logic + Tests [#6932]

### DIFF
--- a/src/monitor-plan-workspace/monitor-plan-checks.service.spec.ts
+++ b/src/monitor-plan-workspace/monitor-plan-checks.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 
 import { UnitStackConfigurationChecksService } from '../unit-stack-configuration-workspace/unit-stack-configuration-checks.service';
@@ -133,6 +134,177 @@ describe('Monitor Plan Checks Service Test', () => {
       expect(monitorSystemCheckService.runChecks).toHaveBeenCalled();
       expect(monitorSpanCheckService.runChecks).toHaveBeenCalled();
       expect(unitStackConfigurationChecksService.runChecks).toHaveBeenCalled();
+        });
+      });
+
+  // Tests Location lookup with anyOf schema compliance
+  describe('Location Lookup - anyOf Schema Compliance', () => {
+    const mockLocationIdentifiers = [
+      { locationId: 'LOC1', unitId: '3', stackPipeId: null },
+      { locationId: 'LOC2', unitId: null, stackPipeId: 'CS1' },
+      { locationId: 'LOC3', unitId: '4', stackPipeId: 'CS2' },
+    ];
+
+    it('should find location with unitId only', async () => {
+      const testPayload = new UpdateMonitorPlanDTO();
+      testPayload.unitStackConfigurationData = [];
+
+      const testLocation = new UpdateMonitorLocationDTO();
+      testLocation.unitId = '3';
+      testLocation.stackPipeId = null;
+      testPayload.monitoringLocationData = [testLocation];
+
+      // Mock the service to return the test location identifiers
+      const mockService = {
+        runChecks: jest.fn().mockResolvedValue([mockLocationIdentifiers, []]),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [LoggerModule],
+        providers: [
+          MonitorPlanChecksService,
+          { provide: MonitorLocationChecksService, useValue: mockService },
+          { provide: MatsMethodChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitControlChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: ComponentCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSystemCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSpanChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitStackConfigurationChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+        ],
+      }).compile();
+
+      const testService = module.get(MonitorPlanChecksService);
+
+      // Should not throw an error
+      await expect(testService.runChecks(testPayload)).resolves.not.toThrow();
+    });
+
+    it('should find location with stackPipeId only', async () => {
+      const testPayload = new UpdateMonitorPlanDTO();
+      testPayload.unitStackConfigurationData = [];
+
+      const testLocation = new UpdateMonitorLocationDTO();
+      testLocation.unitId = null;
+      testLocation.stackPipeId = 'CS1';
+      testPayload.monitoringLocationData = [testLocation];
+
+      const mockService = {
+        runChecks: jest.fn().mockResolvedValue([mockLocationIdentifiers, []]),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [LoggerModule],
+        providers: [
+          MonitorPlanChecksService,
+          { provide: MonitorLocationChecksService, useValue: mockService },
+          { provide: MatsMethodChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitControlChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: ComponentCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSystemCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSpanChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitStackConfigurationChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+        ],
+      }).compile();
+
+      const testService = module.get(MonitorPlanChecksService);
+
+      await expect(testService.runChecks(testPayload)).resolves.not.toThrow();
+    });
+
+    it('should find location with both identifiers', async () => {
+      const testPayload = new UpdateMonitorPlanDTO();
+      testPayload.unitStackConfigurationData = [];
+
+      const testLocation = new UpdateMonitorLocationDTO();
+      testLocation.unitId = '4';
+      testLocation.stackPipeId = 'CS2';
+      testPayload.monitoringLocationData = [testLocation];
+
+      const mockService = {
+        runChecks: jest.fn().mockResolvedValue([mockLocationIdentifiers, []]),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [LoggerModule],
+        providers: [
+          MonitorPlanChecksService,
+          { provide: MonitorLocationChecksService, useValue: mockService },
+          { provide: MatsMethodChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitControlChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: ComponentCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSystemCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSpanChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitStackConfigurationChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+        ],
+      }).compile();
+
+      const testService = module.get(MonitorPlanChecksService);
+
+      await expect(testService.runChecks(testPayload)).resolves.not.toThrow();
+    });
+
+    it('should throw error when no location found', async () => {
+      const testPayload = new UpdateMonitorPlanDTO();
+      testPayload.unitStackConfigurationData = [];
+
+      const testLocation = new UpdateMonitorLocationDTO();
+      testLocation.unitId = '999';
+      testLocation.stackPipeId = null;
+      testPayload.monitoringLocationData = [testLocation];
+
+      const mockService = {
+        runChecks: jest.fn().mockResolvedValue([mockLocationIdentifiers, []]),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [LoggerModule],
+        providers: [
+          MonitorPlanChecksService,
+          { provide: MonitorLocationChecksService, useValue: mockService },
+          { provide: MatsMethodChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitControlChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: ComponentCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSystemCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSpanChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitStackConfigurationChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+        ],
+      }).compile();
+
+      const testService = module.get(MonitorPlanChecksService);
+
+      await expect(testService.runChecks(testPayload)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should handle empty location identifiers', async () => {
+      const testPayload = new UpdateMonitorPlanDTO();
+      testPayload.unitStackConfigurationData = [];
+
+      const testLocation = new UpdateMonitorLocationDTO();
+      testLocation.unitId = '3';
+      testLocation.stackPipeId = null;
+      testPayload.monitoringLocationData = [testLocation];
+
+      const mockService = {
+        runChecks: jest.fn().mockResolvedValue([[], []]), // Empty location identifiers
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [LoggerModule],
+        providers: [
+          MonitorPlanChecksService,
+          { provide: MonitorLocationChecksService, useValue: mockService },
+          { provide: MatsMethodChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitControlChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: ComponentCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSystemCheckService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: MonitorSpanChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+          { provide: UnitStackConfigurationChecksService, useValue: { runChecks: jest.fn().mockResolvedValue([]) } },
+        ],
+      }).compile();
+
+      const testService = module.get(MonitorPlanChecksService);
+
+      await expect(testService.runChecks(testPayload)).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/monitor-plan-workspace/monitor-plan-checks.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan-checks.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, BadRequestException } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { ComponentCheckService } from '../component-workspace/component-checks.service';
@@ -67,12 +67,24 @@ export class MonitorPlanChecksService {
     });
 
     payload.monitoringLocationData.forEach((monitorLocation, locIdx) => {
-      const locationId = locationIdentifiers.find(i => {
-        return (
-          i.unitId === monitorLocation.unitId &&
-          i.stackPipeId === monitorLocation.stackPipeId
+      //Fix anyOf schema compliance for location lookup
+      const location = locationIdentifiers.find(i => {
+        if (monitorLocation.unitId && monitorLocation.stackPipeId) {
+          return i.unitId === monitorLocation.unitId && i.stackPipeId === monitorLocation.stackPipeId;
+        } else if (monitorLocation.unitId) {
+          return i.unitId === monitorLocation.unitId;
+        } else if (monitorLocation.stackPipeId) {
+          return i.stackPipeId === monitorLocation.stackPipeId;
+        }
+        return false;
+      });
+
+      if (!location) {
+        throw new BadRequestException(
+          `Location not found for unitId: ${monitorLocation.unitId}, stackPipeId: ${monitorLocation.stackPipeId}`
         );
-      }).locationId;
+      }
+      const locationId = location.locationId;
 
       monitorLocation.supplementalMATSMonitoringMethodData?.forEach(
         (matsMethod, matsMetIdx) => {

--- a/src/monitor-plan-workspace/monitor-plan.service.spec.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 import { EntityManager, SelectQueryBuilder } from 'typeorm';
 
@@ -538,6 +539,162 @@ describe('Monitor Plan Service', () => {
         true,
         true,
       );
+    });
+  });
+
+  // Tests -- Array access safety for location handling
+  describe('Array Access Safety - TT6932', () => {
+    it('should handle empty locations array safely', async () => {
+      const mockMethod = {
+        id: 'method-id-123',
+      };
+
+      const mockQueryBuilder = {
+        createQueryBuilder: jest.fn().mockReturnThis(),
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          locations: [], // Empty locations array
+          beginReportingPeriod: { year: 2020 },
+          endReportPeriodId: null,
+        }),
+      } as any;
+
+      const mockRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      } as any;
+
+      // Test the private method
+      const serviceInstance = service as any;
+      serviceInstance.repository = mockRepository;
+
+      // Test:  To throw BadRequestException due to empty locations array
+      await expect(
+        serviceInstance.updateFirstPlanPeriodOnMethodUpdateIfSingleUnit({
+          method: mockMethod,
+          userId: 'testuser',
+          trx: undefined
+        })
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith('mp');
+    });
+
+    it('should process single location plan safely', async () => {
+      const mockMethod = {
+        id: 'method-id-123',
+      };
+
+      const mockQueryBuilder = {
+        createQueryBuilder: jest.fn().mockReturnThis(),
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          locations: [{ unitId: '1', stackPipeId: null }], // Single location
+          beginReportingPeriod: { year: 2020 },
+          endReportPeriodId: null,
+        }),
+      } as any;
+
+      const mockRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      } as any;
+
+      const serviceInstance = service as any;
+      serviceInstance.repository = mockRepository;
+      serviceInstance.syncSingleUnitPlanBeginRptPeriodToEarliestMethod = jest.fn().mockResolvedValue(undefined);
+
+      // Should complete successfully
+      await expect(
+         serviceInstance.updateFirstPlanPeriodOnMethodUpdateIfSingleUnit({
+          method: mockMethod,
+          userId: 'testuser',
+          trx: undefined
+        })
+      ).resolves.not.toThrow();
+    // Verify nested method was called for valid single location
+      expect(serviceInstance.syncSingleUnitPlanBeginRptPeriodToEarliestMethod).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return early for multi-location plans', async () => {
+      const mockMethod = {
+        id: 'method-id-123',
+      };
+
+      const mockQueryBuilder = {
+        createQueryBuilder: jest.fn().mockReturnThis(),
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          locations: [
+            { unitId: '1', stackPipeId: null },
+            { unitId: '2', stackPipeId: null }
+          ], // For multiple locations
+          beginReportingPeriod: { year: 2020 },
+          endReportPeriodId: null,
+        }),
+      } as any;
+
+      const mockRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      } as any;
+
+      const serviceInstance = service as any;
+      serviceInstance.repository = mockRepository;
+
+      // Should return early for multi-location plans
+      await expect(
+        serviceInstance.updateFirstPlanPeriodOnMethodUpdateIfSingleUnit({
+          method: mockMethod,
+          userId: 'testuser',
+          trx: undefined
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('should return early when no plan found', async () => {
+      const mockMethod = {
+        id: 'method-id-123',
+      };
+
+      const mockQueryBuilder = {
+        createQueryBuilder: jest.fn().mockReturnThis(),
+        innerJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null), // No plan found
+      } as any;
+
+      const mockRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+      } as any;
+
+      const serviceInstance = service as any;
+      serviceInstance.repository = mockRepository;
+
+      // Should return early when no plan found
+      await expect(
+        serviceInstance.updateFirstPlanPeriodOnMethodUpdateIfSingleUnit({
+          method: mockMethod,
+          userId: 'testuser',
+          trx: undefined
+        })
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/src/monitor-plan-workspace/monitor-plan.service.ts
+++ b/src/monitor-plan-workspace/monitor-plan.service.ts
@@ -2385,6 +2385,11 @@ export class MonitorPlanWorkspaceService {
 
     if (!firstPlan) return;
     if (firstPlan.locations.length > 1) return; // Only single-location plans.
+
+    // Check unsafe array access with proper null checking
+    if (firstPlan.locations.length === 0) {
+      throw new BadRequestException('No locations found in monitor plan');
+    }
     if (firstPlan.locations[0].unitId === null) return; // Only single-unit plans.
     if (firstPlan.endReportPeriodId) return; // Only active plans.
     if (firstPlan.beginReportingPeriod.year < 2008) return; // Only plans with begin dates after 2008.


### PR DESCRIPTION
### Summary:
Users experiencing import crashes with error: "Cannot read properties of undefined (reading 'locationId')" when importing QA/EM files containing only unitId OR stackPipeId (not both). JSON schema uses anyOf validation but code required both fields.
### Changes Made:
- Updated unsafe location lookup patterns across 3 APIs
- All QA/EM/MP files with single identifiers process correctly
- Enhanced error messages guide users toward resolution
### Tests:
- Unit test validated single identifier lookups (unitId only, stackPipeId only, both)
- Error handling tests -- verify BadRequestException behavior
- Edge case tests -- handle empty/null values safely

```