### PR TITLE
Fix/6894 logical keys

### DIFF
--- a/src/monitor-span-workspace/monitor-span.repository.ts
+++ b/src/monitor-span-workspace/monitor-span.repository.ts
@@ -25,14 +25,20 @@ export class MonitorSpanWorkspaceRepository extends Repository<MonitorSpan> {
   ): Promise<MonitorSpan | null> {
     const query = this.createQueryBuilder('ms')
       .where('ms.locationId = :locationId', { locationId })
-      .andWhere('ms.componentTypeCode = :componentTypeCode', { componentTypeCode })
+      .andWhere('ms.componentTypeCode = :componentTypeCode', {
+        componentTypeCode,
+      })
       .andWhere('ms.beginDate = :beginDate', { beginDate })
       .andWhere('ms.beginHour = :beginHour', { beginHour })
-      .andWhere('ms.spanScaleCode = :spanScaleCode', { spanScaleCode: spanScaleCode ?? IsNull() })
+
+    if (spanScaleCode === null || spanScaleCode === undefined) {
+      query.andWhere('ms.spanScaleCode IS NULL');
+    } else {
+      query.andWhere('ms.spanScaleCode = :spanScaleCode', { spanScaleCode });
+    }
 
     return query.getOne();
   }
-
 
   async getSpanByLocIdCompTypeCdEDateEHour(
     locationId: string,

--- a/src/monitor-span-workspace/monitor-span.repository.ts
+++ b/src/monitor-span-workspace/monitor-span.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { EntityManager, IsNull, Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 
 import { MonitorSpan } from '../entities/workspace/monitor-span.entity';
 


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6894

## Main Changes:

- Explicitly use `IS NULL` rather than TypeORM's `IsNull()` when building SQL strings using QueryBuilder. The instance in question evaluated to `span_scale_cd = NULL`, which will always be false. `IsNull()` should only be used when building queries with the object pattern, e.g. `findBy`.