### PR TITLE
Update MONLOC-106-A and MONLOC-107-B checks to validate against database

### DIFF
--- a/src/import-checks/import-checks.service.ts
+++ b/src/import-checks/import-checks.service.ts
@@ -55,7 +55,7 @@ export class ImportChecksService {
     );
 
     // Unit Stack Checks
-    errorList.push(...this.unitStackService.runUnitStackChecks(monPlan));
+    errorList.push(...await this.unitStackService.runUnitStackChecks(monPlan, facilityId));
 
     // Stack Pipe Checks
     errorList.push(

--- a/src/stack-pipe-workspace/stack-pipe.service.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.ts
@@ -4,6 +4,7 @@ import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
 import { EntityManager } from 'typeorm';
 import { v4 as uuid } from 'uuid';
+import { CheckCatalogService } from '@us-epa-camd/easey-common';
 
 import { MonitorLocationBaseDTO } from '../dtos/monitor-location-base.dto';
 import { UpdateMonitorLocationDTO } from '../dtos/monitor-location-update.dto';
@@ -151,14 +152,27 @@ export class StackPipeWorkspaceService {
     const errorList: string[] = [];
 
     // Check if there are any duplicate stack/pipe IDs.
-    const stackPipeIds = locations.map(sp => sp.stackPipeId).filter(Boolean);
-    stackPipeIds.forEach((stackPipeId, i) => {
-      if (stackPipeIds.findIndex(sp => sp === stackPipeId) !== i) {
-        errorList.push(
-          `[MONLOC-106-A] Duplicate Stack/Pipe found with ID: ${stackPipeId}`,
-        );
+    for (const location of locations) {
+      if (location.stackPipeId) {
+        try {
+          const existingStackPipe = await this.getStackByNameAndFacId(
+            location.stackPipeId,
+            facId,
+          );
+
+          if (existingStackPipe) {
+            const error = CheckCatalogService.formatResultMessage('MONLOC-106-A', {
+              fieldnames: 'stackPipeId',
+              recordtype: 'Stack Pipe'
+            });
+            errorList.push(error);
+            break;
+          }
+        } catch (error) {
+          continue;
+        }
       }
-    });
+    }
 
     await Promise.all(
       locations.map(async location => {

--- a/src/stack-pipe-workspace/stack-pipe.service.ts
+++ b/src/stack-pipe-workspace/stack-pipe.service.ts
@@ -154,22 +154,21 @@ export class StackPipeWorkspaceService {
     // Check if there are any duplicate stack/pipe IDs.
     for (const location of locations) {
       if (location.stackPipeId) {
-        try {
-          const existingStackPipe = await this.getStackByNameAndFacId(
-            location.stackPipeId,
-            facId,
-          );
-
-          if (existingStackPipe) {
-            const error = CheckCatalogService.formatResultMessage('MONLOC-106-A', {
-              fieldnames: 'stackPipeId',
-              recordtype: 'Stack Pipe'
-            });
-            errorList.push(error);
-            break;
-          }
-        } catch (error) {
-          continue;
+        const queryRunner = this.entityManager.connection.createQueryRunner();
+        await queryRunner.startTransaction();
+        const trx = queryRunner.manager;
+        const existingStackPipe = await this.getStackByNameAndFacId(
+          location.stackPipeId,
+          facId,
+          trx
+        ).catch(() => null);
+        if (existingStackPipe) {
+          const error = CheckCatalogService.formatResultMessage('MONLOC-106-A', {
+            fieldnames: 'stackPipeId',
+            recordtype: 'Stack Pipe'
+          });
+          errorList.push(error);
+          break;
         }
       }
     }

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.spec.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.spec.ts
@@ -41,15 +41,34 @@ unitStackConfig.unitId = unitID;
 mpPayload.unitStackConfigurationData = [unitStackConfig];
 mpPayload.monitoringLocationData = [location];
 
+// Mock CheckCatalogService
+jest.mock('@us-epa-camd/easey-common', () => ({
+  CheckCatalogService: {
+    formatResultMessage: jest.fn().mockImplementation((code, params) => {
+      if (code === 'MONLOC-107-A') {
+        return '[MONLOC-107-A]';
+      }
+      if (code === 'MONLOC-107-B') {
+        return '[MONLOC-107-B]';
+      }
+      if (code === 'IMPORT-4-A') {
+        return '[IMPORT-4-A]';
+      }
+      return `[${code}]`;
+    }),
+  },
+}));
+
 const mockRepository = () => ({
   getUnitStackById: jest.fn().mockResolvedValue(unitStack),
   save: jest.fn().mockResolvedValue(unitStack),
-  find: jest.fn().mockResolvedValue(unitStack),
+  find: jest.fn().mockResolvedValue([unitStack]),
   findOne: jest.fn().mockResolvedValue(undefined),
   update: jest.fn(),
   create: jest.fn().mockResolvedValue('Why'),
   getUnitStackConfigsByLocationIds: jest.fn().mockResolvedValue([unitStack]),
-  getUnitStackConfigByUnitIdStackId: jest.fn().mockResolvedValue(unitStack),
+  getUnitStackConfigByUnitIdStackId: jest.fn().mockResolvedValue(null), // Default to null for tests
+  findOneBy: jest.fn().mockResolvedValue(undefined),
 });
 
 const mockMap = () => ({
@@ -58,11 +77,17 @@ const mockMap = () => ({
 });
 
 const mockStackPipe = () => ({
-  getStackByNameAndFacId: jest.fn().mockResolvedValue(''),
+  getStackByNameAndFacId: jest.fn().mockResolvedValue({
+    id: 'stack-id',
+    name: 'TEST',
+  }),
 });
 
 const mockUnit = () => ({
-  getUnitByNameAndFacId: jest.fn().mockResolvedValue(''),
+  getUnitByNameAndFacId: jest.fn().mockResolvedValue({
+    id: 1,
+    name: 'TEST',
+  }),
 });
 const mockUnitMap = () => ({
   many: jest.fn().mockResolvedValue([unitDto]),
@@ -72,6 +97,8 @@ const mockUnitMap = () => ({
 describe('UnitStackConfigurationWorkspaceService', () => {
   let service: UnitStackConfigurationWorkspaceService;
   let repo: UnitStackConfigurationWorkspaceRepository;
+  let stackPipeService: StackPipeWorkspaceService;
+  let unitService: UnitService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -107,6 +134,10 @@ describe('UnitStackConfigurationWorkspaceService', () => {
     service = module.get<UnitStackConfigurationWorkspaceService>(
       UnitStackConfigurationWorkspaceService,
     );
+    stackPipeService = module.get<StackPipeWorkspaceService>(
+      StackPipeWorkspaceService,
+    );
+    unitService = module.get<UnitService>(UnitService);
   });
 
   describe('getUnitStackConfigsByLocationIds', () => {
@@ -158,7 +189,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
 
   describe('Import Unit Stack Checks', () => {
     describe('Check3', () => {
-      it('Should pass given aligned unit stack config and unit data', () => {
+      it('Should pass given aligned unit stack config and unit data', async () => {
         const unitStackConfig = new UnitStackConfigurationBaseDTO();
         unitStackConfig.unitId = 'TEST';
         unitStackConfig.stackPipeId = 'TEST';
@@ -171,11 +202,11 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         plan.unitStackConfigurationData = [unitStackConfig];
         plan.monitoringLocationData = [location];
 
-        const result = service.runUnitStackChecks(plan);
+        const result = await service.runUnitStackChecks(plan, facilityId);
         expect(result.length).toBe(0);
       });
 
-      it('Should fail given unit stack not in unit stack config', () => {
+      it('Should fail given unit stack not in unit stack config', async () => {
         const unitStackConfig = new UnitStackConfigurationBaseDTO();
         unitStackConfig.unitId = 'TEST';
         unitStackConfig.stackPipeId = 'TEST';
@@ -192,7 +223,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         plan.unitStackConfigurationData = [unitStackConfig];
         plan.monitoringLocationData = [location, location2];
 
-        const result = service.runUnitStackChecks(plan);
+        const result = await service.runUnitStackChecks(plan, facilityId);
         expect(result).toEqual([
           '[IMPORT3-FATAL-A] Each stack or pipe must be associated with at least one unit. StackName TESTING is not associated with any units.',
         ]);
@@ -223,7 +254,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
     //   });
     // });
     describe('Check8', () => {
-      it('Should fail given unit stack config stackId not in location', () => {
+      it('Should fail given unit stack config stackId not in location', async () => {
         const unitStackConfig = new UnitStackConfigurationBaseDTO();
         unitStackConfig.unitId = 'TEST';
         unitStackConfig.stackPipeId = 'TEST';
@@ -240,7 +271,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         plan.unitStackConfigurationData = [unitStackConfig, unitStackConfig2];
         plan.monitoringLocationData = [location];
 
-        const result = service.runUnitStackChecks(plan);
+        const result = await service.runUnitStackChecks(plan, facilityId);
         expect(result).toEqual([
           `[IMPORT8-CRIT1-A] Each Stack/Pipe and Unit in a unit stack configuration record must be linked to unit and stack/pipe records that are also present in the file. StackPipeID TESTING was not associated with a Stack/Pipe record in the file.`,
         ]);
@@ -248,7 +279,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
     });
 
     describe('Check8', () => {
-      it('Should fail given unit stack config unitId not in location', () => {
+      it('Should fail given unit stack config unitId not in location', async () => {
         const unitStackConfig = new UnitStackConfigurationBaseDTO();
         unitStackConfig.unitId = 'TEST';
         unitStackConfig.stackPipeId = 'TEST';
@@ -265,7 +296,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
         plan.unitStackConfigurationData = [unitStackConfig, unitStackConfig2];
         plan.monitoringLocationData = [location];
 
-        const result = service.runUnitStackChecks(plan);
+        const result = await service.runUnitStackChecks(plan, facilityId);
         expect(result).toEqual([
           `[IMPORT8-CRIT1-B] Each Stack/Pipe and Unit in a unit stack configuration record must be linked to unit and stack/pipe records that are also present in the file. UnitID TESTING was not associated with a Unit record in the file. This StackPipe Configuration Record was not imported.`,
         ]);
@@ -275,6 +306,10 @@ describe('UnitStackConfigurationWorkspaceService', () => {
 
   describe('importUnitStacks', () => {
     it('should update while importing unit stack config', async () => {
+      jest
+        .spyOn(repo, 'getUnitStackConfigByUnitIdStackId')
+        .mockResolvedValue(unitStack);
+
       const response = await service.importUnitStacks(
         mpPayload,
         facilityId,
@@ -298,7 +333,7 @@ describe('UnitStackConfigurationWorkspaceService', () => {
   });
 
   describe('MONLOC-107 check', () => {
-    it('should return MONLOC-107-A error when unitId is missing in unit stack configuration', () => {
+    it('should return MONLOC-107-A error when unitId is missing in unit stack configuration', async () => {
       const unitStackConfig = new UnitStackConfigurationBaseDTO();
       unitStackConfig.unitId = null;
       unitStackConfig.stackPipeId = 'TEST';
@@ -307,33 +342,30 @@ describe('UnitStackConfigurationWorkspaceService', () => {
       plan.unitStackConfigurationData = [unitStackConfig];
       plan.monitoringLocationData = [];
 
-      const result = service.runUnitStackChecks(plan);
+      const result = await service.runUnitStackChecks(plan, facilityId);
 
       expect(result).toContain('[MONLOC-107-A]');
     });
 
-    it('should return MONLOC-107-B error when duplicate unit stack configuration exists', () => {
-      const sameBeginDate = new Date('2023-01-01');
+    it('should return MONLOC-107-B error when duplicate unit stack configuration exists in database', async () => {
+      jest
+        .spyOn(repo, 'getUnitStackConfigByUnitIdStackId')
+        .mockResolvedValue(unitStack);
 
       const unitStackConfig1 = new UnitStackConfigurationBaseDTO();
       unitStackConfig1.unitId = 'TEST';
       unitStackConfig1.stackPipeId = 'CS0AN';
-      unitStackConfig1.beginDate = sameBeginDate;
-
-      const unitStackConfig2 = new UnitStackConfigurationBaseDTO();
-      unitStackConfig2.unitId = 'TEST';
-      unitStackConfig2.stackPipeId = 'CS0AN';
-      unitStackConfig2.beginDate = sameBeginDate;
+      unitStackConfig1.beginDate = new Date('2023-01-01');
 
       const location1 = new UpdateMonitorLocationDTO();
       location1.unitId = 'TEST';
       location1.stackPipeId = 'CS0AN';
 
       const plan = new UpdateMonitorPlanDTO();
-      plan.unitStackConfigurationData = [unitStackConfig1, unitStackConfig2];
+      plan.unitStackConfigurationData = [unitStackConfig1];
       plan.monitoringLocationData = [location1];
 
-      const result = service.runUnitStackChecks(plan);
+      const result = await service.runUnitStackChecks(plan, facilityId);
       const monloc107BErrors = result.filter(error => error.includes('MONLOC-107-B'));
 
       expect(monloc107BErrors.length).toBeGreaterThan(0);

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -65,46 +65,155 @@ export class UnitStackConfigurationWorkspaceService {
   async runUnitStackChecks(monitorPlan: UpdateMonitorPlanDTO, facilityId: number): Promise<string[]> {
     const errorList: string[] = [];
 
-    // Check for duplicate unit stack configurations.
+    await this.validateUnitStackConfigs(monitorPlan, facilityId, errorList);
+    this.validateConfigLocationRelationships(monitorPlan, errorList);
+    this.validateStackUnitAssociations(monitorPlan, errorList);
+
+    return errorList
+  }
+
+  private async validateUnitStackConfigs(
+    monitorPlan: UpdateMonitorPlanDTO,
+    facilityId: number,
+    errorList: string[],
+  ): Promise<void> {
     for (const unitStackConfig of monitorPlan.unitStackConfigurationData) {
-      if (!unitStackConfig.unitId) {
-        const error = CheckCatalogService.formatResultMessage('MONLOC-107-A', {
-          fieldname: 'unitId',
-          key: KEY
-        })
-        errorList.push(error)
-      }
+      this.validateUnitStackConfig(unitStackConfig, errorList);
+
       if (unitStackConfig.unitId && unitStackConfig.stackPipeId) {
-        try {
-          const stackPipe = await this.stackPipeService.getStackByNameAndFacId(
-            unitStackConfig.stackPipeId,
-            facilityId,
-          );
-          const unit = await this.unitService.getUnitByNameAndFacId(
-            unitStackConfig.unitId,
-            facilityId,
-          );
-          const existingConfig = await withTransaction(
-            this.repository,
-          ).getUnitStackConfigByUnitIdStackId(unit.id, stackPipe.id);
-          if (existingConfig) {
-            const error = CheckCatalogService.formatResultMessage('MONLOC-107-B', {
-              recordtype: KEY,
-              fieldnames: 'unitId, stackPipeId',
-            })
-            errorList.push(error);
-            break;
-          }
-        } catch (error) {
-          continue;
-        }
+        const hasDuplicate = await this.checkDatabaseDuplicate(
+          unitStackConfig,
+          facilityId,
+          errorList,
+        );
+        if (hasDuplicate) return;
+      }
+    }
+  }
+  private validateUnitStackConfig(
+    config: UnitStackConfigurationBaseDTO,
+    errorList: string[],
+  ): void {
+    if (!config.unitId) {
+      const error = CheckCatalogService.formatResultMessage('MONLOC-107-A', {
+        fieldname: 'unitId',
+        key: KEY,
+      });
+      errorList.push(error);
+    }
+  }
+  private async checkDatabaseDuplicate(
+    config: UnitStackConfigurationBaseDTO,
+    facilityId: number,
+    errorList: string[],
+  ): Promise<boolean> {
+
+    const stackPipe = await this.stackPipeService.getStackByNameAndFacId(
+      config.stackPipeId,
+      facilityId,
+    ).catch(() => null);
+
+    if (!stackPipe) return false;
+
+    const unit = await this.unitService.getUnitByNameAndFacId(
+      config.unitId,
+      facilityId,
+    ).catch(() => null);
+    if (!unit) return false;
+
+
+    const existingConfig = await this.repository.getUnitStackConfigByUnitIdStackId(
+      unit.id,
+      stackPipe.id,
+    ).catch(() => null);
+
+    if (existingConfig) {
+      const error = CheckCatalogService.formatResultMessage('MONLOC-107-B', {
+        recordtype: KEY,
+        fieldnames: 'unitId, stackPipeId',
+      });
+      errorList.push(error);
+      return true;
+    }
+
+    return false;
+  }
+  private validateConfigLocationRelationships(
+    monitorPlan: UpdateMonitorPlanDTO,
+    errorList: string[],
+  ): void {
+    const { unitStackIds, unitUnitIds } = this.extractLocationIds(monitorPlan);
+
+    for (const unitStackConfig of monitorPlan.unitStackConfigurationData) {
+      this.validateConfigReferences(unitStackConfig, unitStackIds, unitUnitIds, errorList);
+    }
+  }
+
+  private validateConfigReferences(
+    config: UnitStackConfigurationBaseDTO,
+    unitStackIds: Set<string>,
+    unitUnitIds: Set<string>,
+    errorList: string[],
+  ): void {
+    if (!unitStackIds.has(config.stackPipeId)) {
+      errorList.push(
+        `[IMPORT8-CRIT1-A] Each Stack/Pipe and Unit in a unit stack configuration record must be linked to unit and stack/pipe records that are also present in the file. StackPipeID ${config.stackPipeId} was not associated with a Stack/Pipe record in the file.`,
+      );
+    }
+
+    if (!unitUnitIds.has(config.unitId)) {
+      errorList.push(
+        `[IMPORT8-CRIT1-B] Each Stack/Pipe and Unit in a unit stack configuration record must be linked to unit and stack/pipe records that are also present in the file. UnitID ${config.unitId} was not associated with a Unit record in the file. This StackPipe Configuration Record was not imported.`,
+      );
+    }
+  }
+
+  private validateStackUnitAssociations(
+    monitorPlan: UpdateMonitorPlanDTO,
+    errorList: string[],
+  ): void {
+    const unitStackIds = this.extractStackIdsFromLocations(monitorPlan);
+    const unitStackConfigStackIds = this.extractStackIdsFromConfigs(monitorPlan);
+
+    for (const stackPipe of unitStackIds) {
+      if (!unitStackConfigStackIds.has(stackPipe)) {
+        errorList.push(
+          `[IMPORT3-FATAL-A] Each stack or pipe must be associated with at least one unit. StackName ${stackPipe} is not associated with any units.`,
+        );
+      }
+    }
+  }
+
+  private extractStackIdsFromLocations(monitorPlan: UpdateMonitorPlanDTO): Set<string> {
+    const unitStackIds: Set<string> = new Set<string>();
+
+    for (const location of monitorPlan.monitoringLocationData) {
+      if (location.stackPipeId) {
+        unitStackIds.add(location.stackPipeId);
       }
     }
 
-    const unitStackIds: Set<string> = new Set<string>(); // Set for faster look up times
-    const unitUnitIds: Set<string> = new Set<string>();
+    return unitStackIds;
+  }
 
+  private extractStackIdsFromConfigs(monitorPlan: UpdateMonitorPlanDTO): Set<string> {
     const unitStackConfigStackIds: Set<string> = new Set<string>();
+
+    for (const unitStackConfig of monitorPlan.unitStackConfigurationData) {
+      if (unitStackConfig.stackPipeId) {
+        unitStackConfigStackIds.add(unitStackConfig.stackPipeId);
+      }
+    }
+
+    return unitStackConfigStackIds;
+  }
+
+  private extractLocationIds(monitorPlan: UpdateMonitorPlanDTO): {
+    unitStackIds: Set<string>;
+    unitUnitIds: Set<string>;
+  } {
+    const unitStackIds: Set<string> = new Set<string>();
+    const unitUnitIds: Set<string> = new Set<string>();
 
     for (const location of monitorPlan.monitoringLocationData) {
       if (location.stackPipeId) {
@@ -115,32 +224,7 @@ export class UnitStackConfigurationWorkspaceService {
       }
     }
 
-    for (const unitStackConfig of monitorPlan.unitStackConfigurationData) {
-      if (!unitStackIds.has(unitStackConfig.stackPipeId)) {
-        errorList.push(
-          `[IMPORT8-CRIT1-A] Each Stack/Pipe and Unit in a unit stack configuration record must be linked to unit and stack/pipe records that are also present in the file. StackPipeID ${unitStackConfig.stackPipeId} was not associated with a Stack/Pipe record in the file.`,
-        );
-      }
-
-      if (!unitUnitIds.has(unitStackConfig.unitId)) {
-        errorList.push(
-          `[IMPORT8-CRIT1-B] Each Stack/Pipe and Unit in a unit stack configuration record must be linked to unit and stack/pipe records that are also present in the file. UnitID ${unitStackConfig.unitId} was not associated with a Unit record in the file. This StackPipe Configuration Record was not imported.`,
-        );
-      }
-
-      unitStackConfigStackIds.add(unitStackConfig.stackPipeId);
-    }
-
-    for (const stackPipe of unitStackIds) {
-      if (!unitStackConfigStackIds.has(stackPipe)) {
-        errorList.push(
-          //CheckCatalogService.formatResultMessage('IMPORT-3-A', { stackName: stackPipe }),
-          `[IMPORT3-FATAL-A] Each stack or pipe must be associated with at least one unit. StackName ${stackPipe} is not associated with any units.`,
-        );
-      }
-    }
-
-    return errorList;
+    return { unitStackIds, unitUnitIds };
   }
 
   async importUnitStackConfigurationChecks(monPlan: UpdateMonitorPlanDTO): Promise<string[]> {

--- a/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
+++ b/src/unit-stack-configuration-workspace/unit-stack-configuration.service.ts
@@ -62,30 +62,44 @@ export class UnitStackConfigurationWorkspaceService {
     return await this.repository.getUnitStackConfigsByLocationIds(locationIds);
   }
 
-  runUnitStackChecks(monitorPlan: UpdateMonitorPlanDTO): string[] {
+  async runUnitStackChecks(monitorPlan: UpdateMonitorPlanDTO, facilityId: number): Promise<string[]> {
     const errorList: string[] = [];
 
     // Check for duplicate unit stack configurations.
-    monitorPlan.unitStackConfigurationData.forEach((usc1, i) => {
-      if (!usc1.unitId) {
+    for (const unitStackConfig of monitorPlan.unitStackConfigurationData) {
+      if (!unitStackConfig.unitId) {
         const error = CheckCatalogService.formatResultMessage('MONLOC-107-A', {
           fieldname: 'unitId',
           key: KEY
         })
         errorList.push(error)
-      } else if (
-        monitorPlan.unitStackConfigurationData.findIndex(
-          usc2 =>
-            usc1.unitId === usc2.unitId &&
-            usc1.stackPipeId === usc2.stackPipeId &&
-            usc1.beginDate === usc2.beginDate,
-        ) !== i
-      ) {
-        errorList.push(
-          `[MONLOC-107-B] Duplicate Unit Stack Configuration record found at index #${i}.`,
-        );
       }
-    });
+      if (unitStackConfig.unitId && unitStackConfig.stackPipeId) {
+        try {
+          const stackPipe = await this.stackPipeService.getStackByNameAndFacId(
+            unitStackConfig.stackPipeId,
+            facilityId,
+          );
+          const unit = await this.unitService.getUnitByNameAndFacId(
+            unitStackConfig.unitId,
+            facilityId,
+          );
+          const existingConfig = await withTransaction(
+            this.repository,
+          ).getUnitStackConfigByUnitIdStackId(unit.id, stackPipe.id);
+          if (existingConfig) {
+            const error = CheckCatalogService.formatResultMessage('MONLOC-107-B', {
+              recordtype: KEY,
+              fieldnames: 'unitId, stackPipeId',
+            })
+            errorList.push(error);
+            break;
+          }
+        } catch (error) {
+          continue;
+        }
+      }
+    }
 
     const unitStackIds: Set<string> = new Set<string>(); // Set for faster look up times
     const unitUnitIds: Set<string> = new Set<string>();


### PR DESCRIPTION
## Ticket
[Check Gaps: MP Screen Only and Import Checks](https://github.com/US-EPA-CAMD/easey-ui/issues/6907)

## Change
- Update MONLOC-106-A and MONLOC-107-B checks to validate against database