### PR TITLE
Fix/6894 monitor default null fields

### DIFF
--- a/src/monitor-default-workspace/monitor-default.repository.ts
+++ b/src/monitor-default-workspace/monitor-default.repository.ts
@@ -27,14 +27,30 @@ export class MonitorDefaultWorkspaceRepository extends Repository<
     beginDate: Date,
     beginHour: number,
   ): Promise<MonitorDefault | null> {
-    return this.createQueryBuilder('md')
+    const query = this.createQueryBuilder('md')
       .where('md.locationId = :locationId', { locationId })
       .andWhere('md.parameterCode = :parameterCode', { parameterCode })
-      .andWhere('md.defaultPurposeCode = :defaultPurposeCode', { defaultPurposeCode })
-      .andWhere('md.fuelCode = :fuelCode', { fuelCode })
-      .andWhere('md.operatingConditionCode = :operatingConditionCode', { operatingConditionCode })
       .andWhere('md.beginDate = :beginDate', { beginDate })
-      .andWhere('md.beginHour = :beginHour', { beginHour })
-      .getOne();
+      .andWhere('md.beginHour = :beginHour', { beginHour });
+
+    if (defaultPurposeCode === null || defaultPurposeCode === undefined) {
+      query.andWhere('md.defaultPurposeCode IS NULL');
+    } else {
+      query.andWhere('md.defaultPurposeCode = :defaultPurposeCode', { defaultPurposeCode });
+    }
+
+    if (fuelCode === null || fuelCode === undefined) {
+      query.andWhere('md.fuelCode IS NULL');
+    } else {
+      query.andWhere('md.fuelCode = :fuelCode', { fuelCode });
+    }
+
+    if (operatingConditionCode === null || operatingConditionCode === undefined) {
+      query.andWhere('md.operatingConditionCode IS NULL');
+    } else {
+      query.andWhere('md.operatingConditionCode = :operatingConditionCode', { operatingConditionCode });
+    }
+
+    return query.getOne();
   }
 }


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6894

## Main Changes:

- Use the proper `IS NULL` syntax instead of `= NULL` for nullable fields in the Monitor Default query.