### PR TITLE
Feature/6037 bulk import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ test-report.xml
 .vscode/*
 !.vscode/tasks.json
 !.vscode/launch.json
+
+# build
+*.tsbuildinfo

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -6,8 +6,15 @@ import {
   Param,
   Controller,
   Query,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOkResponse, ApiSecurity } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOkResponse,
+  ApiSecurity,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { ClientTokenGuard } from '@us-epa-camd/easey-common/guards';
 
 import { MonitorPlanDTO } from '../dtos/monitor-plan.dto';
 import { MonitorPlanImportResponseDTO } from '../dtos/monitor-plan-import-response.dto';
@@ -115,6 +122,25 @@ export class MonitorPlanWorkspaceController {
     await this.importChecksService.runImportChecks(plan);
     await this.mpChecksService.runChecks(plan);
     return await this.service.importMpPlan(plan, user.userId, draft);
+  }
+
+  @Post('import/bulk')
+  @ApiSecurity('ClientId')
+  @ApiBearerAuth('ClientToken')
+  @UseGuards(ClientTokenGuard)
+  @ApiOkResponse({
+    type: MonitorPlanImportResponseDTO,
+    description:
+      'Imports a monitor plan on behalf of a user for the bulk import job',
+  })
+  async importPlanBulk(
+    @Body() plan: UpdateMonitorPlanDTO,
+    @Query('userId') userId: string,
+    @Query('draft') draft: boolean,
+  ): Promise<MonitorPlanImportResponseDTO> {
+    await this.importChecksService.runImportChecks(plan);
+    await this.mpChecksService.runChecks(plan);
+    return await this.service.importMpPlan(plan, userId, draft);
   }
 
   @Post('single-unit')

--- a/src/monitor-plan-workspace/monitor-plan.controller.ts
+++ b/src/monitor-plan-workspace/monitor-plan.controller.ts
@@ -133,6 +133,15 @@ export class MonitorPlanWorkspaceController {
     description:
       'Imports a monitor plan on behalf of a user for the bulk import job',
   })
+  @AuditLog({
+    label: 'Imported monitoring plan on behalf of a user for the bulk import job',
+    requestBodyOutFields: [
+      'orisCode',
+      'unitStackConfigurationData.unitId',
+      'unitStackConfigurationData.stackPipeId',
+      'monitoringLocationData.unitId',
+    ],
+  })
   async importPlanBulk(
     @Body() plan: UpdateMonitorPlanDTO,
     @Query('userId') userId: string,

--- a/src/user-check-out/user-check-out.service.spec.ts
+++ b/src/user-check-out/user-check-out.service.spec.ts
@@ -60,7 +60,7 @@ describe('UserCheckOutService', () => {
   describe('checkOutConfiguration', () => {
     it('should check out a configuration and return it', async () => {
       jest
-        .spyOn(service as any, 'ensureNoEvaluationOrSubmissionInProgress')
+        .spyOn(service as any, 'ensureNoEvaluationSubmissionOrImportInProgress')
         .mockResolvedValue(true);
       const result = await service.checkOutConfiguration(null, null);
       expect(result).toEqual(userCheckoutDto);

--- a/src/user-check-out/user-check-out.service.ts
+++ b/src/user-check-out/user-check-out.service.ts
@@ -25,7 +25,7 @@ export class UserCheckOutService {
     monPlanId: string,
     username: string,
   ): Promise<UserCheckOutDTO> {
-    if (!(await this.ensureNoEvaluationOrSubmissionInProgress(monPlanId))) {
+    if (!(await this.ensureNoEvaluationSubmissionOrImportInProgress(monPlanId))) {
       throw new EaseyException(
         new Error(
           'Record can not be checked out. It is currently being evaluated or submitted.',
@@ -60,7 +60,7 @@ export class UserCheckOutService {
     return this.map.one(record);
   }
 
-  private async ensureNoEvaluationOrSubmissionInProgress(
+  private async ensureNoEvaluationSubmissionOrImportInProgress(
     monPlanId: string,
     trx?: EntityManager,
   ) {
@@ -81,9 +81,20 @@ export class UserCheckOutService {
       [monPlanId],
     );
 
+    // NEW is excluded: a draft import is still being assembled (its plan is
+    // checked out to the user), so only QUEUED/WIP imports lock the plan.
+    const importRecordsInProgress = await (trx ?? this.returnManager()).query(
+      `SELECT * FROM CAMDECMPSAUX.import_set iset
+       JOIN CAMDECMPSAUX.import_queue iq USING(import_set_id)
+       WHERE iq.mon_plan_id = $1 AND iset.status_cd NOT IN ('NEW', 'COMPLETE', 'ERROR');
+      `,
+      [monPlanId],
+    );
+
     if (
       (evalRecordsInProgress && evalRecordsInProgress.length > 0) ||
-      (submissionRecordsInProgress && submissionRecordsInProgress.length > 0)
+      (submissionRecordsInProgress && submissionRecordsInProgress.length > 0) ||
+      (importRecordsInProgress && importRecordsInProgress.length > 0)
     ) {
       return false;
     }
@@ -118,7 +129,7 @@ export class UserCheckOutService {
     trx?: EntityManager,
   ): Promise<boolean> {
     if (
-      !(await this.ensureNoEvaluationOrSubmissionInProgress(monPlanId, trx))
+      !(await this.ensureNoEvaluationSubmissionOrImportInProgress(monPlanId, trx))
     ) {
       throw new EaseyException(
         new Error(

--- a/src/user-check-out/user-check-out.service.ts
+++ b/src/user-check-out/user-check-out.service.ts
@@ -81,12 +81,10 @@ export class UserCheckOutService {
       [monPlanId],
     );
 
-    // NEW is excluded: a draft import is still being assembled (its plan is
-    // checked out to the user), so only QUEUED/WIP imports lock the plan.
     const importRecordsInProgress = await (trx ?? this.returnManager()).query(
       `SELECT * FROM CAMDECMPSAUX.import_set iset
        JOIN CAMDECMPSAUX.import_queue iq USING(import_set_id)
-       WHERE iq.mon_plan_id = $1 AND iset.status_cd NOT IN ('NEW', 'COMPLETE', 'ERROR');
+       WHERE iq.mon_plan_id = $1 AND iset.status_cd NOT IN ('COMPLETE', 'ERROR');
       `,
       [monPlanId],
     );

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "incremental": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist",
-    "incremental": false
+    "outDir": "./dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6037

## Main Changes:

- Create an import endpoint that can be called by the Bulk Import job. This is functionally identical to the existing import endpoint, but with different authorization.
- Update the checkout guard to also make sure the plan is not being imported before allowing to check out or in.